### PR TITLE
[CLEANUP] Clean up the installation instructions and the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # Collmex API PHP SDK
 
-This library provides a wrapper for the Collmex API. It's not complete yet, some record types (and maybe
-some features) are missing.
+This library provides a wrapper for the Collmex API. It's not complete yet,
+some record types (and maybe some features) are missing.
 
-Please create a Pull Request if you've implemented a new type/feature or create Issues for bugs/feature requests.
+Please create a pull request if you have implemented a new type/feature or
+create issues for bugs/feature requests.
 
-There is (or least should be…) a *Type* class for every Collmex record type ("Satzart"). Currently only the base types (`MESSAGE`, `LOGIN`, `NEW_OBJECT_ID`) and a few normal record types are implemented:
+There is (or least should be…) a *Type* class for every Collmex record type
+("Satzart"). Currently only the base types (`MESSAGE`, `LOGIN`,
+`NEW_OBJECT_ID`) and a few normal record types are implemented:
 
 - `ABO_GET`
 - `CMXABO`
@@ -43,7 +46,8 @@ Using Composer, just add it to your `composer.json` by running:
 composer require mjaschen/collmex
 ```
 
-If you want to use the included Laravel service provider `CollmexServiceProvider`, add it to the `config/app.php` providers array:
+If you want to use the included Laravel service provider
+`CollmexServiceProvider`, add it to the `config/app.php` providers array:
 
 ```php
 return [
@@ -52,7 +56,7 @@ return [
 
     'providers' => [
         // ...
-        MarcusJaschen\Collmex\CollmexServiceProvider::class,
+        \MarcusJaschen\Collmex\CollmexServiceProvider::class,
     ],
 
     // ...
@@ -61,9 +65,9 @@ return [
 
 ## Compatibility
 
-The Collmex PHP SDK requires PHP 5.5.9. If you're still using older PHP versions, you can install the 0.4 branch
-for PHP 5.4 compatibility or the 0.3 branch for PHP 5.3 compatibility. New features will only go into the current
-branch.
+The Collmex PHP SDK requires PHP >= 5.5.9. If you're still using an older PHP
+version, you can install the 0.4 branch for PHP 5.4 compatibility or the 0.3
+branch for PHP 5.3 compatibility. New features will only go into the master.
 
 ## Usage/Examples
 
@@ -79,7 +83,7 @@ use \MarcusJaschen\Collmex\Request;
 use \MarcusJaschen\Collmex\Type\CustomerGet;
 
 // initialize HTTP client
-$collmexClient = new CurlClient("USER", "PASSWORD", "CUSTOMER_ID");
+$collmexClient = new CurlClient('USER', 'PASSWORD', 'CUSTOMER_ID');
 
 // create request object
 $collmexRequest = new Request($collmexClient);
@@ -91,22 +95,24 @@ $getCustomerType = new CustomerGet(array('customer_id' => '12345'));
 $collmexResponse = $collmexRequest->send($getCustomerType->getCsv());
 
 if ($collmexResponse->isError()) {
-    echo "Collmex error: " . $collmexResponse->getErrorMessage() . "; Code=" . $collmexResponse->getErrorCode() . PHP_EOL;
+    echo 'Collmex error: ' . $collmexResponse->getErrorMessage() . '; Code=' . $collmexResponse->getErrorCode() . PHP_EOL;
 } else {
     $records = $collmexResponse->getRecords();
 
     foreach ($records as $record) {
-        var_dump($record->getData()); // contains one Customer object and the Message object(s)
+        // contains one Customer object and the Message object(s)
+        var_dump($record->getData());
     }
 }
 
-// show unparsed reponse contents:
+// show unparsed response contents:
 var_dump($collmexResponse->getResponseRaw());
 ```
 
 ### Create a new Collmex customer record
 
-Create a new Collmex *Customer* record and get the Collmex Customer-ID from the response data:
+Create a new Collmex *Customer* record and get the Collmex customer ID from the
+response data:
 
 ```php
 <?php
@@ -116,7 +122,7 @@ use \MarcusJaschen\Collmex\Request;
 use \MarcusJaschen\Collmex\Type\Customer;
 
 // initialize HTTP client
-$collmexClient = new CurlClient("USER", "PASSWORD", "CUSTOMER_ID");
+$collmexClient = new CurlClient('USER', 'PASSWORD', 'CUSTOMER_ID');
 
 // create request object
 $collmexRequest = new Request($collmexClient);
@@ -124,17 +130,17 @@ $collmexRequest = new Request($collmexClient);
 // create a record type; we create a customer with some basic fields
 $customer = new Customer(
     array(
-        'client_id'                      => "2",
-        'salutation'                     => "Herr",
-        'forename'                       => "Charly",
-        'lastname'                       => "Cash",
-        'street'                         => "Hauptstraße 12",
-        'zipcode'                        => "12222",
-        'city'                           => "Berlin",
+        'client_id'                      => '2',
+        'salutation'                     => 'Herr',
+        'forename'                       => 'Charly',
+        'lastname'                       => 'Cash',
+        'street'                         => 'Hauptstraße 12',
+        'zipcode'                        => '12222',
+        'city'                           => 'Berlin',
         'inactive'                       => Customer::STATUS_ACTIVE,
-        'country'                        => "DE",
-        'phone'                          => "+49300000000",
-        'email'                          => "cash@example.org",
+        'country'                        => 'DE',
+        'phone'                          => '+49300000000',
+        'email'                          => 'cash@example.org',
         'output_medium'                  => Customer::OUTPUT_MEDIUM_EMAIL,
     )
 );
@@ -143,34 +149,36 @@ $customer = new Customer(
 $collmexResponse = $collmexRequest->send($customer->getCsv());
 
 if ($collmexResponse->isError()) {
-    echo "Collmex error: " . $collmexResponse->getErrorMessage() . "; Code=" . $collmexResponse->getErrorCode() . PHP_EOL;
+    echo 'Collmex error: ' . $collmexResponse->getErrorMessage() . '; Code=' . $collmexResponse->getErrorCode() . PHP_EOL;
 } else {
     $newObject = $collmexResponse->getFirstRecord();
-    echo "New Collmex customer ID=" . $newObject->new_id . PHP_EOL;
+    echo 'New Collmex customer ID=' . $newObject->new_id . PHP_EOL;
 
     $records = $collmexResponse->getRecords();
 
     foreach ($records as $record) {
-        var_dump($record->getData()); // contains one NewObject object and the Message object(s)
+        // contains one NewObject object and the Message object(s)
+        var_dump($record->getData());
     }
 }
 ```
 
 ## Notes
 
-Collmex expects all strings encoded in Codepage 1252 (Windows) while the Collmex PHP SDK expects
-all inputs as UTF-8 and outputs everything as UTF-8. The conversion of string encodings is done
-transparently before sending an request to the Collmex API and after receiving the response from
-the API.
+Collmex expects all strings encoded in code page 1252 (Windows) while the
+Collmex PHP SDK expects all inputs as UTF-8 and outputs everything as UTF-8.
+The conversion of string encodings is done transparently before sending a
+request to the Collmex API and after receiving the response from the API.
 
 ## Run Tests
 
-- Install with `--dev` option: `php composer.phar install --dev` or `php composer.phar update --dev`
-- run `./vendor/bin/phpunit`
+```shell
+./vendor/bin/phpunit
+```
 
 ## Collmex API Documentation
 
-- [http://www.collmex.de/cgi-bin/cgi.exe?1005,1,help,api](http://www.collmex.de/cgi-bin/cgi.exe?1005,1,help,api)
+https://www.collmex.de/cgi-bin/cgi.exe?1005,1,help,api
 
 ## Contributions
 


### PR DESCRIPTION
- fix a few typos
- break the lines at 80 characters
- drop the instructions for installing with development dependencies
  (which is the default in current Composer versions)
- add a version restriction to the `composer require` as unbounded
  dependencies are not recommended
- use single quotes in the PHP code
- drop the [] and () for links as links are rendered automatically
  in Markdown