### PR TITLE
[CLEANUP] Have a distinct namespace for the tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,11 @@
             "MarcusJaschen\\Collmex\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "MarcusJaschen\\Collmex\\Tests\\": "tests/"
+        }
+    },
     "extra": {
         "laravel": {
             "providers": [

--- a/tests/Csv/LeagueCsvGeneratorTest.php
+++ b/tests/Csv/LeagueCsvGeneratorTest.php
@@ -1,11 +1,13 @@
 <?php
 
-namespace MarcusJaschen\Collmex\Csv;
+namespace MarcusJaschen\Collmex\Tests\Csv;
+
+use MarcusJaschen\Collmex\Csv\LeagueCsvGenerator;
 
 class LeagueCsvGeneratorTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var SimpleGenerator
+     * @var LeagueCsvGenerator
      */
     protected $generator;
 

--- a/tests/Csv/SimpleGeneratorTest.php
+++ b/tests/Csv/SimpleGeneratorTest.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace MarcusJaschen\Collmex\Csv;
+namespace MarcusJaschen\Collmex\Tests\Csv;
+
+use MarcusJaschen\Collmex\Csv\SimpleGenerator;
 
 class SimpleGeneratorTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Csv/SimpleParserTest.php
+++ b/tests/Csv/SimpleParserTest.php
@@ -1,5 +1,8 @@
 <?php
-class SimpleParserTest extends PHPUnit_Framework_TestCase
+
+namespace MarcusJaschen\Collmex\Tests\Csv;
+
+class SimpleParserTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var \MarcusJaschen\Collmex\Csv\SimpleParser

--- a/tests/Filter/Utf8ToWindows1252Test.php
+++ b/tests/Filter/Utf8ToWindows1252Test.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace MarcusJaschen\Collmex\Filter;
+namespace MarcusJaschen\Collmex\Tests\Filter;
 
 class Utf8ToWindows1252Test extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Filter/Windows1252ToUtf8Test.php
+++ b/tests/Filter/Windows1252ToUtf8Test.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace MarcusJaschen\Collmex\Filter;
+namespace MarcusJaschen\Collmex\Tests\Filter;
 
 class Windows1252ToUtf8Test extends \PHPUnit_Framework_TestCase
 {

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace MarcusJaschen\Collmex;
+namespace MarcusJaschen\Collmex\Tests;
 
 use \Mockery as m;
 use \MarcusJaschen\Collmex\Response\CsvResponse;

--- a/tests/Type/SubscriptionTest.php
+++ b/tests/Type/SubscriptionTest.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace MarcusJaschen\Collmex\Type;
+namespace MarcusJaschen\Collmex\Tests\Type;
+
+use MarcusJaschen\Collmex\Type\Subscription;
 
 class SubscriptionTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Type/Validator/DateOrEmptyTest.php
+++ b/tests/Type/Validator/DateOrEmptyTest.php
@@ -1,4 +1,7 @@
 <?php
+
+namespace MarcusJaschen\Collmex\Tests\Type\Validator;
+
 class DateOrEmptyTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Type/Validator/DateTest.php
+++ b/tests/Type/Validator/DateTest.php
@@ -1,4 +1,7 @@
 <?php
+
+namespace MarcusJaschen\Collmex\Tests\Type\Validator;
+
 class DateTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Type/Validator/TimeIntervalTest.php
+++ b/tests/Type/Validator/TimeIntervalTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace MarcusJaschen\Collmex\Type\Validator;
+namespace MarcusJaschen\Collmex\Tests\Type\Validator;
 
 use MarcusJaschen\Collmex\Type\Subscription;
+use MarcusJaschen\Collmex\Type\Validator\TimeInterval;
 
 class TimeIntervalTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/TypeFactoryTest.php
+++ b/tests/TypeFactoryTest.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace MarcusJaschen\Collmex;
+namespace MarcusJaschen\Collmex\Tests;
+
+use MarcusJaschen\Collmex\TypeFactory;
 
 class TypeFactoryTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
Also add this namespace the the dev autoload section in the
composer.json.

Also add imports as needed and fix an incorrect type annotation.

The regression tests currently do not have a suitable namespace yet;
 they need to be integrated into the other tests firsts.