### PR TITLE
[TASK] Don't announce PHP 7.3 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": ">=5.6",
+        "php": "^5.6.0 || ~7.0.0 || ~7.1.0 || ~7.2.0",
         "neitanod/forceutf8": "~1.4.0",
         "symfony/finder": ">2.5.0,<4.0",
         "symfony/http-foundation": ">2.5.0,<4.0"


### PR DESCRIPTION
As this library has not been tested with PHP 7.3 yet, the composer.json
should only state compatibility with PHP up to 7.2.x.

(Using ^7.0.0 would allow PHP 7.x.y. So the requirement needs to be up
to ~7.2.0, which is 7.2.x.)