### PR TITLE
[TASK] Drop rendundant composer update and install from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,6 @@ install:
   fi;
   composer show;
 
-before_script:
-  - curl -s http://getcomposer.org/installer | php
-  - php composer.phar install
-
 script:
 - >
   echo;


### PR DESCRIPTION
Travis already always does a composer update, and the composer install
already is done in the install section of the .travis.yml.