### PR TITLE
[TASK] Make the runtime dependencies more lenient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/)
 principles.
 
+## [x.y.z] - not released yet
+
+### Added
+
+* support auto-discovery
+
+### Changed
+
+* make the runtime dependencies more lenient
+* announce PHP compatibility only up to 7.2.x
+
 ## [0.7.0] - 2018-01-07
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -20,14 +20,14 @@
     },
     "require": {
         "php": "^5.6.0 || ~7.0.0 || ~7.1.0 || ~7.2.0",
-        "neitanod/forceutf8": "~1.4.0",
-        "symfony/finder": ">2.5.0,<4.0",
-        "symfony/http-foundation": ">2.5.0,<4.0"
+        "neitanod/forceutf8": "^1.4.0 || ^2.0.0",
+        "symfony/finder": "^2.5.0 || ^3.0.0 || ^4.0.0",
+        "symfony/http-foundation": "^2.5.0 || ^3.0.0 || ^4.0.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.7.26",
-        "mockery/mockery": "~1.0",
-        "league/csv": "^8.0"
+        "phpunit/phpunit": "^5.7.26",
+        "mockery/mockery": "^1.0",
+        "league/csv": "^8.2.0"
     },
     "suggest": {
         "league/csv": "Enable CSV generation via the 'Csv' library by The PHP League"


### PR DESCRIPTION
As this library should be usable for a wide range of projects that
also might have other library dependencies, this library's dependencies
should be as lenient as possible in their version requirements, and
use ^ version constraints.

Also update the development dependencies to their latest version.