### PR TITLE
[CLEANUP] Switch to the short array syntax

### DIFF
--- a/src/Client/Curl.php
+++ b/src/Client/Curl.php
@@ -66,7 +66,7 @@ class Curl extends AbstractClient implements ClientInterface
     {
         $this->curl = curl_init($this->exchangeUrl);
         curl_setopt($this->curl, CURLOPT_POST, true);
-        curl_setopt($this->curl, CURLOPT_HTTPHEADER, array("Content-Type: text/csv"));
+        curl_setopt($this->curl, CURLOPT_HTTPHEADER, ["Content-Type: text/csv"]);
         curl_setopt($this->curl, CURLOPT_SSL_VERIFYPEER, true);
         curl_setopt($this->curl, CURLOPT_RETURNTRANSFER, true);
     }

--- a/src/CollmexServiceProvider.php
+++ b/src/CollmexServiceProvider.php
@@ -83,9 +83,9 @@ class CollmexServiceProvider extends \Illuminate\Support\ServiceProvider
      */
     public function provides()
     {
-        return array(
+        return [
             'collmex.client',
             'collmex.request',
-        );
+        ];
     }
 }

--- a/src/Type/Customer.php
+++ b/src/Type/Customer.php
@@ -40,7 +40,7 @@ class Customer extends AbstractType implements TypeInterface
      *
      * @var array
      */
-    protected $template = array(
+    protected $template = [
         'type_identifier'                => 'CMXKND',   // 1
         'customer_id'                    => null,       //
         'client_id'                      => null,       //
@@ -93,7 +93,7 @@ class Customer extends AbstractType implements TypeInterface
         'url'                            => null,       // 50
         'partial_delivery_allowed'       => null,       //
         'partial_invoice_allowed'        => null,       // 52
-    );
+    ];
 
     /**
      * Formally validates the type data in $data attribute.

--- a/src/Type/CustomerGet.php
+++ b/src/Type/CustomerGet.php
@@ -21,7 +21,7 @@ class CustomerGet extends AbstractType implements TypeInterface
     /**
      * @var array
      */
-    protected $template = array(
+    protected $template = [
         'type_identifier'  => 'CUSTOMER_GET',
         'customer_id'      => null,
         'client_id'        => null,
@@ -36,7 +36,7 @@ class CustomerGet extends AbstractType implements TypeInterface
         'system_name'      => null,
         'inactive'         => null,
 
-    );
+    ];
 
     /**
      * Formally validates the type data in $data attribute.

--- a/src/Type/Invoice.php
+++ b/src/Type/Invoice.php
@@ -52,7 +52,7 @@ class Invoice extends AbstractType implements TypeInterface
      *
      * @var array
      */
-    protected $template = array(
+    protected $template = [
         'type_identifier'                => 'CMXINV',
         'invoice_id'                     => null,
         'position'                       => null,
@@ -140,7 +140,7 @@ class Invoice extends AbstractType implements TypeInterface
         'costs'                          => null,
         'gross_profit'                   => null,
         'margin'                         => null,
-    );
+    ];
 
     /**
      * Formally validates the type data in $data attribute.

--- a/src/Type/InvoiceGet.php
+++ b/src/Type/InvoiceGet.php
@@ -27,7 +27,7 @@ class InvoiceGet extends AbstractType implements TypeInterface
     /**
      * @var array
      */
-    protected $template = array(
+    protected $template = [
         'type_identifier'        => 'INVOICE_GET',
         'invoice_id'             => null,
         'client_id'              => null,
@@ -40,7 +40,7 @@ class InvoiceGet extends AbstractType implements TypeInterface
         'system_name'            => null,
         'created_by_system_only' => null,
         'stationary_exclude'     => null,
-    );
+    ];
 
     /**
      * Formally validates the type data in $data attribute.

--- a/src/Type/Login.php
+++ b/src/Type/Login.php
@@ -18,11 +18,11 @@ namespace MarcusJaschen\Collmex\Type;
  */
 class Login extends AbstractType implements TypeInterface
 {
-    protected $template = array(
+    protected $template = [
         'type_identifier' => 'LOGIN',
         'user'            => null,
         'password'        => null,
-    );
+    ];
 
     /**
      * Formally validates the type data in $data attribute.

--- a/src/Type/Member.php
+++ b/src/Type/Member.php
@@ -42,7 +42,7 @@ class Member extends AbstractType implements TypeInterface
      *
      * @var array
      */
-    protected $template = array(
+    protected $template = [
         'type_identifier'             => 'CMXMGD',   // 1
         'customer_id'                 => null,       //
         'salutation'                  => null,       //
@@ -80,7 +80,7 @@ class Member extends AbstractType implements TypeInterface
         'payment_via'                 => null,       // 35
         'printout_language'           => null,       //
         'cost_center'                 => null,       //
-    );
+    ];
 
     /**
      * Formally validates the type data in $data attribute.

--- a/src/Type/Message.php
+++ b/src/Type/Message.php
@@ -21,13 +21,13 @@ class Message extends AbstractType implements TypeInterface
     /**
      * @var array
      */
-    protected $template = array(
+    protected $template = [
         'type_identifier' => 'MESSAGE',
         'message_type'    => null,
         'message_id'      => null,
         'message_text'    => null,
         'line'            => null,
-    );
+    ];
 
     /**
      * Formally validates the type data in $data attribute.

--- a/src/Type/NewObject.php
+++ b/src/Type/NewObject.php
@@ -18,12 +18,12 @@ namespace MarcusJaschen\Collmex\Type;
  */
 class NewObject extends AbstractType implements TypeInterface
 {
-    protected $template = array(
+    protected $template = [
         'type_identifier' => 'NEW_OBJECT_ID',
         'new_id'          => null,
         'temporary_id'    => null,
         'line'            => null,
-    );
+    ];
 
     /**
      * Formally validates the type data in $data attribute.

--- a/src/Type/Revenue.php
+++ b/src/Type/Revenue.php
@@ -21,7 +21,7 @@ class Revenue extends AbstractType implements TypeInterface
     /**
      * @var array
      */
-    protected $template = array(
+    protected $template = [
         'type_identifier'                => 'CMXUMS',
         'customer_id'                    => null,
         'client_id'                      => null,
@@ -50,7 +50,7 @@ class Revenue extends AbstractType implements TypeInterface
         'system_name'                    => null,
         'compensation_invoice_id'        => null,
         'cost_center'                    => null, // 28
-    );
+    ];
 
     /**
      * Formally validates the type data in $data attribute.

--- a/src/Type/SalesOrderGet.php
+++ b/src/Type/SalesOrderGet.php
@@ -30,7 +30,7 @@ class SalesOrderGet extends AbstractType implements TypeInterface
     /**
      * @var array
      */
-    protected $template = array(
+    protected $template = [
         'type_identifier'           => 'SALES_ORDER_GET',
         'order_id'                  => null,
         'client_id'                 => null,
@@ -43,7 +43,7 @@ class SalesOrderGet extends AbstractType implements TypeInterface
         'system_name'               => null,    // 10
         'only_created_by_system'    => null,
         'letter_paper'              => null,
-    );
+    ];
 
     /**
      * Formally validates the type data in $data attribute.

--- a/src/Type/Subscription.php
+++ b/src/Type/Subscription.php
@@ -32,7 +32,7 @@ class Subscription extends AbstractType implements TypeInterface
      *
      * @var array
      */
-    protected $template = array(
+    protected $template = [
         'type_identifier'     => 'CMXABO',
         'customer_id'         => null,
         'client_id'           => null,
@@ -43,7 +43,7 @@ class Subscription extends AbstractType implements TypeInterface
         'price'               => null,
         'interval'            => null,
         'next_invoice'        => null,
-    );
+    ];
 
     /**
      * Formally validates the type data in $data attribute.

--- a/src/Type/SubscriptionGet.php
+++ b/src/Type/SubscriptionGet.php
@@ -21,7 +21,7 @@ class SubscriptionGet extends AbstractType implements TypeInterface
      *
      * @var array
      */
-    protected $template = array(
+    protected $template = [
         'type_identifier'        => 'ABO_GET',
         'customer_id'            => null,
         'client_id'              => null,
@@ -31,7 +31,7 @@ class SubscriptionGet extends AbstractType implements TypeInterface
         'currently_valid_only'   => null,
         'changed_only'           => null,
         'system_name'            => null,
-    );
+    ];
 
     /**
      * Formally validates the type data in $data attribute.

--- a/src/Type/Validator/Date.php
+++ b/src/Type/Validator/Date.php
@@ -28,7 +28,7 @@ class Date implements ValidatorInterface
      *
      * @return bool Validation success
      */
-    public function validate($value, $options = array())
+    public function validate($value, $options = [])
     {
         if (strlen($value) != 8) {
             return false;

--- a/src/Type/Validator/DateOrEmpty.php
+++ b/src/Type/Validator/DateOrEmpty.php
@@ -28,7 +28,7 @@ class DateOrEmpty extends Date implements ValidatorInterface
      *
      * @return bool Validation success
      */
-    public function validate($value, $options = array())
+    public function validate($value, $options = [])
     {
         if (empty($value)) {
             return true;

--- a/src/Type/Validator/TimeInterval.php
+++ b/src/Type/Validator/TimeInterval.php
@@ -28,7 +28,7 @@ class TimeInterval implements ValidatorInterface
      *
      * @return bool Validation success
      */
-    public function validate($value, $options = array())
+    public function validate($value, $options = [])
     {
         return is_int($value) && $value >= 0 && $value <= 7;
     }

--- a/src/Type/Validator/ValidatorInterface.php
+++ b/src/Type/Validator/ValidatorInterface.php
@@ -26,5 +26,5 @@ interface ValidatorInterface
      *
      * @return bool Validation success
      */
-    public function validate($value, $options = array());
+    public function validate($value, $options = []);
 }

--- a/tests/Csv/SimpleGeneratorTest.php
+++ b/tests/Csv/SimpleGeneratorTest.php
@@ -85,11 +85,11 @@ class SimpleGeneratorTest extends \PHPUnit_Framework_TestCase
      */
     public function testGenerateCsvWithSpecialCharactersWorksAsExpected()
     {
-        $data = array(
+        $data = [
             'CMXINV',
             '-1001338',
             'Provision Bikemarkt-Verkauf 279679: "Endura MTR Baggy Short // SALE \\\\" an "bebetz" am 1.1.2016',
-        );
+        ];
 
         $expected = 'CMXINV;-1001338;"Provision Bikemarkt-Verkauf 279679: ""Endura MTR Baggy Short // SALE \\\\"" an ""bebetz"" am 1.1.2016"' . PHP_EOL;
 

--- a/tests/Csv/SimpleParserTest.php
+++ b/tests/Csv/SimpleParserTest.php
@@ -22,13 +22,13 @@ class SimpleParserTest extends PHPUnit_Framework_TestCase
 
         $data = $this->parser->parse($csv);
 
-        $expected = array(
-            array(
+        $expected = [
+            [
                 'Typkennung',
                 'Rechnung Nr',
                 'Pos',
-            )
-        );
+            ]
+        ];
 
         $this->assertEquals($expected, $data);
     }
@@ -39,13 +39,13 @@ class SimpleParserTest extends PHPUnit_Framework_TestCase
 
         $data = $this->parser->parse($csv);
 
-        $expected = array(
-            array(
+        $expected = [
+            [
                 'Typkennung',
                 'Rechnung Nr',
                 'Pos',
-            )
-        );
+            ]
+        ];
 
         $this->assertEquals($expected, $data);
     }
@@ -56,18 +56,18 @@ class SimpleParserTest extends PHPUnit_Framework_TestCase
 
         $data = $this->parser->parse($csv);
 
-        $expected = array(
-            array(
+        $expected = [
+            [
                 'Typkennung',
                 'Rechnung Nr',
                 'Pos',
-            ),
-            array(
+            ],
+            [
                 'CMXINV',
                 100,
                 1,
-            ),
-        );
+            ],
+        ];
 
         $this->assertEquals($expected, $data);
     }

--- a/tests/Filter/Utf8ToWindows1252Test.php
+++ b/tests/Filter/Utf8ToWindows1252Test.php
@@ -32,15 +32,15 @@ class Utf8ToWindows1252Test extends \PHPUnit_Framework_TestCase
         $source = file_get_contents(__DIR__ . DIRECTORY_SEPARATOR . '_fixtures' . DIRECTORY_SEPARATOR . 'utf-8.txt');
         $target = file_get_contents(__DIR__ . DIRECTORY_SEPARATOR . '_fixtures' . DIRECTORY_SEPARATOR . 'cp1252.txt');
 
-        $input = array(
+        $input = [
             $source,
             $source,
-        );
+        ];
 
-        $expected = array(
+        $expected = [
             $target,
             $target,
-        );
+        ];
 
         $this->assertEquals($expected, $this->filter->filter($input));
     }
@@ -50,19 +50,19 @@ class Utf8ToWindows1252Test extends \PHPUnit_Framework_TestCase
         $source = file_get_contents(__DIR__ . DIRECTORY_SEPARATOR . '_fixtures' . DIRECTORY_SEPARATOR . 'utf-8.txt');
         $target = file_get_contents(__DIR__ . DIRECTORY_SEPARATOR . '_fixtures' . DIRECTORY_SEPARATOR . 'cp1252.txt');
 
-        $input = array(
-            array(
+        $input = [
+            [
                 $source,
-            ),
+            ],
             $source,
-        );
+        ];
 
-        $expected = array(
-            array(
+        $expected = [
+            [
                 $target,
-            ),
+            ],
             $target,
-        );
+        ];
 
         $this->assertEquals($expected, $this->filter->filter($input));
     }

--- a/tests/Filter/Windows1252ToUtf8Test.php
+++ b/tests/Filter/Windows1252ToUtf8Test.php
@@ -32,15 +32,15 @@ class Windows1252ToUtf8Test extends \PHPUnit_Framework_TestCase
         $source = file_get_contents(__DIR__ . DIRECTORY_SEPARATOR . '_fixtures' . DIRECTORY_SEPARATOR . 'cp1252.txt');
         $target = file_get_contents(__DIR__ . DIRECTORY_SEPARATOR . '_fixtures' . DIRECTORY_SEPARATOR . 'utf-8.txt');
 
-        $input = array(
+        $input = [
             $source,
             $source,
-        );
+        ];
 
-        $expected = array(
+        $expected = [
             $target,
             $target,
-        );
+        ];
 
         $this->assertEquals($expected, $this->filter->filter($input));
     }
@@ -50,19 +50,19 @@ class Windows1252ToUtf8Test extends \PHPUnit_Framework_TestCase
         $source = file_get_contents(__DIR__ . DIRECTORY_SEPARATOR . '_fixtures' . DIRECTORY_SEPARATOR . 'cp1252.txt');
         $target = file_get_contents(__DIR__ . DIRECTORY_SEPARATOR . '_fixtures' . DIRECTORY_SEPARATOR . 'utf-8.txt');
 
-        $input = array(
-            array(
+        $input = [
+            [
                 $source,
-            ),
+            ],
             $source,
-        );
+        ];
 
-        $expected = array(
-            array(
+        $expected = [
+            [
                 $target,
-            ),
+            ],
             $target,
-        );
+        ];
 
         $this->assertEquals($expected, $this->filter->filter($input));
     }

--- a/tests/Regression/Github/10/Issue10Test.php
+++ b/tests/Regression/Github/10/Issue10Test.php
@@ -22,10 +22,10 @@ class Issue10Test extends \PHPUnit_Framework_TestCase
     public function testIfInvalidFieldNamesThrowException()
     {
         $customerGet = new \MarcusJaschen\Collmex\Type\CustomerGet(
-            array(
+            [
                 'customer_id' => '12345',
                 'foo'         => 'bar',
-            )
+            ]
         );
     }
 }

--- a/tests/Regression/Github/2/Issue2Test.php
+++ b/tests/Regression/Github/2/Issue2Test.php
@@ -28,12 +28,12 @@ class Issue2Test extends \PHPUnit_Framework_TestCase
      */
     public function testGenerateCsvWithSpecialCharactersWorksAsExpected()
     {
-        $data = array(
+        $data = [
             'CMXINV',
             '-1001338',
             'Some string data here: "quoted text // highlight string \\\\" and "foo" bar',
             'baz'
-        );
+        ];
 
         $expected = 'CMXINV;-1001338;"Some string data here: ""quoted text // highlight string \\\\"" and ""foo"" bar";baz' . PHP_EOL;
 

--- a/tests/Type/SubscriptionTest.php
+++ b/tests/Type/SubscriptionTest.php
@@ -12,7 +12,7 @@ class SubscriptionTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->type = new Subscription(
-            array(
+            [
                 'customer_id'         => '12345',
                 'client_id'           => '1',
                 'valid_from'          => '20130901',
@@ -22,7 +22,7 @@ class SubscriptionTest extends \PHPUnit_Framework_TestCase
                 'price'               => null,
                 'interval'            => Subscription::INTERVAL_MONTH,
                 'next_invoice'        => null,
-            )
+            ]
         );
     }
 

--- a/tests/TypeFactoryTest.php
+++ b/tests/TypeFactoryTest.php
@@ -21,14 +21,14 @@ class TypeFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testCreateCustomerTypeSuccessful()
     {
-        $data = array(
+        $data = [
             'CMXKND',
             "12345",
             "1",
             "Herr",
             "Marcus",
             "Jaschen",
-        );
+        ];
 
         $type = $this->typeFactory->getType($data);
 
@@ -37,7 +37,7 @@ class TypeFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testCreateSubscriptionTypeSuccessful()
     {
-        $data = array(
+        $data = [
             'CMXABO',
             "12345",
             "1",
@@ -48,7 +48,7 @@ class TypeFactoryTest extends \PHPUnit_Framework_TestCase
             null,
             7,
             "20131101",
-        );
+        ];
 
         $type = $this->typeFactory->getType($data);
 
@@ -57,7 +57,7 @@ class TypeFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testCreateRevenueTypeWorksAsExpected()
     {
-        $data = array(
+        $data = [
             'CMXUMS',
             10001,
             1,
@@ -73,7 +73,7 @@ class TypeFactoryTest extends \PHPUnit_Framework_TestCase
             null,
             null,
             'EUR',
-        );
+        ];
 
         $type = $this->typeFactory->getType($data);
 
@@ -85,12 +85,12 @@ class TypeFactoryTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidType()
     {
-        $data = array(
+        $data = [
             'INVALID_TYPE',
             'data',
             'foo',
             'bar',
-        );
+        ];
 
         $this->typeFactory->getType($data);
     }


### PR DESCRIPTION
As this library required PHP >= 5.6, using the short array syntax
will be safe.