### PR TITLE
Add "ACCBAL_GET" alias BalanceGet

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ $collmexClient = new CurlClient('USER', 'PASSWORD', 'CUSTOMER_ID');
 // create request object
 $collmexRequest = new Request($collmexClient);
 
+// as an alternative to the above to steps
+$collmexRequest = app()->make('collmex.request');
+
 // create a record type; we're querying the API for customer with ID=12345
 $getCustomerType = new CustomerGet(array('customer_id' => '12345'));
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ $collmexClient = new CurlClient('USER', 'PASSWORD', 'CUSTOMER_ID');
 // create request object
 $collmexRequest = new Request($collmexClient);
 
-// as an alternative to the above to steps
+// as an alternative to the above two steps
 $collmexRequest = app()->make('collmex.request');
 
 // create a record type; we're querying the API for customer with ID=12345

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ There is (or least should be…) a *Type* class for every Collmex record type
 `NEW_OBJECT_ID`) and a few normal record types are implemented:
 
 - `ABO_GET`
+- `ACCBAL_GET`
 - `CMXABO`
 - `CMXDLV`
 - `CMXEPF`

--- a/src/Type/BalanceGet.php
+++ b/src/Type/BalanceGet.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace MarcusJaschen\Collmex\Type;
+
+class BalanceGet extends AbstractType implements TypeInterface
+{
+    /**
+     * @var array
+     */
+    protected $template = [
+        'type_identifier'  => 'ACCBAL_GET',
+        'client_id'        => null,
+        'business_year'    => null,
+        'date_to'          => null,
+        'account_id'       => null,
+        'account_group_id' => null,
+        'customer_id'      => null,
+        'supplier_id'      => null,
+        'cost_center'      => null,
+    ];
+
+    /**
+     * Formally validates the type data in $data attribute.
+     *
+     * @return bool Validation success
+     */
+    public function validate()
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
I've tested the request manually with  `client_id`, `business_year` and `account_id`. However I am not sure how the packages maps those attributes to the fields mentioned in the [collmex balance-get doku](https://www.collmex.de/cgi-bin/cgi.exe?1005,1,help,api_Salden). So maybe someone else should also verify it is working.

How is the mapping done? @mjaschen could you give me a brief overview or point me to the relevant code parts?