### PR TITLE
fix typo in types

### DIFF
--- a/src/TypeFactory.php
+++ b/src/TypeFactory.php
@@ -56,7 +56,7 @@ class TypeFactory
                 return new Message($data);
             case 'NEW_OBJECT_ID':
                 return new NewObject($data);
-            case 'ACCBAL':
+            case 'ACC_BAL':
                 return new AccountBalance($data);
             case 'CMXABO':
                 return new Subscription($data);


### PR DESCRIPTION
This fixes a typo in `TypeFactory`.

I get an error if I call `$response->getRecords()` with the current setting.