### PR TITLE
[CLEANUP] Clean up the request/response-related classes

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -5,8 +5,9 @@ namespace MarcusJaschen\Collmex;
 use MarcusJaschen\Collmex\Client\ClientInterface;
 use MarcusJaschen\Collmex\Csv\ParserInterface;
 use MarcusJaschen\Collmex\Csv\SimpleParser;
+use MarcusJaschen\Collmex\Response\CsvResponse;
 use MarcusJaschen\Collmex\Response\ResponseFactory;
-use MarcusJaschen\Collmex\Response\ResponseInterface;
+use MarcusJaschen\Collmex\Response\ZipResponse;
 
 /**
  * Collmex API Request
@@ -49,7 +50,7 @@ class Request
      *
      * @param string $body The request body
      *
-     * @return ResponseInterface
+     * @return ZipResponse|CsvResponse
      * @throws \MarcusJaschen\Collmex\Exception\InvalidResponseMimeTypeException
      * @throws \MarcusJaschen\Collmex\Client\Exception\RequestFailedException
      */

--- a/src/Response/CsvResponse.php
+++ b/src/Response/CsvResponse.php
@@ -11,6 +11,7 @@ namespace MarcusJaschen\Collmex\Response;
 
 use MarcusJaschen\Collmex\Csv\ParserInterface;
 use MarcusJaschen\Collmex\Filter\Windows1252ToUtf8;
+use MarcusJaschen\Collmex\Type\AbstractType;
 use MarcusJaschen\Collmex\TypeFactory;
 
 /**
@@ -23,7 +24,7 @@ use MarcusJaschen\Collmex\TypeFactory;
 class CsvResponse implements ResponseInterface
 {
     /**
-     * @var \MarcusJaschen\Collmex\Csv\ParserInterface
+     * @var ParserInterface
      */
     protected $parser;
 
@@ -47,7 +48,7 @@ class CsvResponse implements ResponseInterface
     protected $data;
 
     /**
-     * @var array of Type records
+     * @var AbstractType[]
      */
     protected $records;
 
@@ -77,7 +78,7 @@ class CsvResponse implements ResponseInterface
     protected $errorLine;
 
     /**
-     * @param \MarcusJaschen\Collmex\Csv\ParserInterface $parser
+     * @param ParserInterface $parser
      * @param string $responseBody
      */
     public function __construct(ParserInterface $parser, $responseBody)
@@ -171,7 +172,7 @@ class CsvResponse implements ResponseInterface
     /**
      * Returns an array of all response records as Type objects.
      *
-     * @return array|null
+     * @return AbstractType[]|null
      *
      * @throws \MarcusJaschen\Collmex\Exception\InvalidTypeIdentifierException
      */
@@ -196,7 +197,7 @@ class CsvResponse implements ResponseInterface
      * Returns the Type object of the first record (or null if response
      * contains no records).
      *
-     * @return array|null
+     * @return AbstractType|null
      *
      * @throws \MarcusJaschen\Collmex\Exception\InvalidTypeIdentifierException
      */

--- a/src/Response/ResponseFactory.php
+++ b/src/Response/ResponseFactory.php
@@ -19,19 +19,19 @@ class ResponseFactory
     protected $responseParser;
 
     /**
-     * @param string $reponseBody
+     * @param string $responseBody
      * @param \MarcusJaschen\Collmex\Csv\ParserInterface $responseParser
      */
-    public function __construct($reponseBody, ParserInterface $responseParser)
+    public function __construct($responseBody, ParserInterface $responseParser)
     {
-        $this->responseBody   = $reponseBody;
+        $this->responseBody   = $responseBody;
         $this->responseParser = $responseParser;
     }
 
     /**
      * Returns the class name which handles the response ('CsvResponse' or 'ZipResponse')
      *
-     * @return ResponseInterface
+     * @return ZipResponse|CsvResponse
      *
      * @throws \MarcusJaschen\Collmex\Response\Exception\InvalidZipFileException
      * @throws \MarcusJaschen\Collmex\Exception\InvalidResponseMimeTypeException

--- a/src/Response/ResponseInterface.php
+++ b/src/Response/ResponseInterface.php
@@ -9,6 +9,8 @@
 
 namespace MarcusJaschen\Collmex\Response;
 
+use MarcusJaschen\Collmex\Csv\ParserInterface;
+
 /**
  * Interface for Response class
  *

--- a/src/Response/ZipResponse.php
+++ b/src/Response/ZipResponse.php
@@ -12,7 +12,6 @@ namespace MarcusJaschen\Collmex\Response;
 use MarcusJaschen\Collmex\Csv\ParserInterface;
 use MarcusJaschen\Collmex\Response\Exception\InvalidZipFileException;
 use Symfony\Component\Finder\Finder;
-use ZipArchive;
 
 /**
  * Collmex ZIP Response Class
@@ -26,10 +25,10 @@ class ZipResponse implements ResponseInterface
     /**
      * @var string
      */
-    protected $reponseBody;
+    protected $responseBody;
 
     /**
-     * @var \MarcusJaschen\Collmex\Csv\ParserInterface
+     * @var ParserInterface
      */
     protected $responseParser;
 
@@ -39,14 +38,14 @@ class ZipResponse implements ResponseInterface
     protected $extractDirectory;
 
     /**
-     * @param \MarcusJaschen\Collmex\Csv\ParserInterface $responseParser
-     * @param string $reponseBody
+     * @param ParserInterface $responseParser
+     * @param string $responseBody
      *
      * @throws \MarcusJaschen\Collmex\Response\Exception\InvalidZipFileException
      */
-    public function __construct(ParserInterface $responseParser, $reponseBody)
+    public function __construct(ParserInterface $responseParser, $responseBody)
     {
-        $this->reponseBody    = $reponseBody;
+        $this->responseBody   = $responseBody;
         $this->responseParser = $responseParser;
 
         $this->extractFiles();
@@ -102,14 +101,14 @@ class ZipResponse implements ResponseInterface
     protected function extractFiles()
     {
         $tmpFilename = tempnam(sys_get_temp_dir(), 'collmexphp_');
-        file_put_contents($tmpFilename, $this->reponseBody);
+        file_put_contents($tmpFilename, $this->responseBody);
 
         $this->extractDirectory = dirname($tmpFilename) . DIRECTORY_SEPARATOR
                                   . 'collmexphp_extracted_' . basename($tmpFilename);
 
-        $zip = new ZipArchive();
+        $zip = new \ZipArchive();
 
-        if (! $zip->open($tmpFilename)) {
+        if (!$zip->open($tmpFilename)) {
             throw new InvalidZipFileException('Cannot open ZIP archive ' . $tmpFilename);
         }
 


### PR DESCRIPTION
- fix typo: reponse -> response
- make it explicit that the request and the response factory will return
  either of the two available concrete response types so clients will know
  which methods are available on the response
- make more use of namespaces
- provide better type hinting for the getRecords method