### PR TITLE
[CLEANUP] Always have a blank line before the namespace declaration

### DIFF
--- a/src/Client/AbstractClient.php
+++ b/src/Client/AbstractClient.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Client;
 
 use MarcusJaschen\Collmex\Csv\SimpleGenerator;

--- a/src/Client/ClientInterface.php
+++ b/src/Client/ClientInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Client;
 
 /**

--- a/src/Client/Curl.php
+++ b/src/Client/Curl.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Client;
 
 use MarcusJaschen\Collmex\Client\Exception\RequestFailedException;

--- a/src/CollmexServiceProvider.php
+++ b/src/CollmexServiceProvider.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex;
 
 /**

--- a/src/Csv/GeneratorInterface.php
+++ b/src/Csv/GeneratorInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Csv;
 
 /**

--- a/src/Csv/LeagueCsvGenerator.php
+++ b/src/Csv/LeagueCsvGenerator.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Csv;
 
 use League\Csv\Writer;

--- a/src/Csv/LeagueCsvParser.php
+++ b/src/Csv/LeagueCsvParser.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Csv;
 
 use League\Csv\Reader;

--- a/src/Csv/ParserInterface.php
+++ b/src/Csv/ParserInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Csv;
 
 /**

--- a/src/Csv/SimpleGenerator.php
+++ b/src/Csv/SimpleGenerator.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Csv;
 
 /**

--- a/src/Csv/SimpleParser.php
+++ b/src/Csv/SimpleParser.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Csv;
 
 /**

--- a/src/Filter/FilterInterface.php
+++ b/src/Filter/FilterInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Filter;
 
 /**

--- a/src/Filter/Utf8ToWindows1252.php
+++ b/src/Filter/Utf8ToWindows1252.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Filter;
 
 use ForceUTF8\Encoding;

--- a/src/Filter/Windows1252ToUtf8.php
+++ b/src/Filter/Windows1252ToUtf8.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Filter;
 
 use ForceUTF8\Encoding;

--- a/src/Request.php
+++ b/src/Request.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex;
 
 use MarcusJaschen\Collmex\Client\ClientInterface;

--- a/src/Response/CsvResponse.php
+++ b/src/Response/CsvResponse.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Response;
 
 use MarcusJaschen\Collmex\Csv\ParserInterface;

--- a/src/Response/ResponseFactory.php
+++ b/src/Response/ResponseFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Response;
 
 use MarcusJaschen\Collmex\Csv\ParserInterface;

--- a/src/Response/ResponseInterface.php
+++ b/src/Response/ResponseInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Response;
 
 /**

--- a/src/Response/ZipResponse.php
+++ b/src/Response/ZipResponse.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Response;
 
 use MarcusJaschen\Collmex\Csv\ParserInterface;

--- a/src/Type/AbstractType.php
+++ b/src/Type/AbstractType.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 use JsonSerializable;

--- a/src/Type/AccountBalance.php
+++ b/src/Type/AccountBalance.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/AccountBalanceGet.php
+++ b/src/Type/AccountBalanceGet.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/AccountDocument.php
+++ b/src/Type/AccountDocument.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/AccountDocumentGet.php
+++ b/src/Type/AccountDocumentGet.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/BillOfMaterial.php
+++ b/src/Type/BillOfMaterial.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/BillOfMaterialGet.php
+++ b/src/Type/BillOfMaterialGet.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/Customer.php
+++ b/src/Type/Customer.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/CustomerGet.php
+++ b/src/Type/CustomerGet.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/CustomerOrder.php
+++ b/src/Type/CustomerOrder.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/Delivery.php
+++ b/src/Type/Delivery.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/DeliveryGet.php
+++ b/src/Type/DeliveryGet.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/DifferentShippingAddress.php
+++ b/src/Type/DifferentShippingAddress.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/Exception/InvalidFieldNameException.php
+++ b/src/Type/Exception/InvalidFieldNameException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type\Exception;
 
 /**

--- a/src/Type/Invoice.php
+++ b/src/Type/Invoice.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/InvoiceGet.php
+++ b/src/Type/InvoiceGet.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/InvoiceOutputSet.php
+++ b/src/Type/InvoiceOutputSet.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/Login.php
+++ b/src/Type/Login.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/Member.php
+++ b/src/Type/Member.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/MemberGet.php
+++ b/src/Type/MemberGet.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/Message.php
+++ b/src/Type/Message.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/NewObject.php
+++ b/src/Type/NewObject.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/OpenItem.php
+++ b/src/Type/OpenItem.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/OpenItemsGet.php
+++ b/src/Type/OpenItemsGet.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/PaymentConfirmation.php
+++ b/src/Type/PaymentConfirmation.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/Product.php
+++ b/src/Type/Product.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/ProductGet.php
+++ b/src/Type/ProductGet.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/ProductPrice.php
+++ b/src/Type/ProductPrice.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/ProductPriceChange.php
+++ b/src/Type/ProductPriceChange.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/ProductPriceGet.php
+++ b/src/Type/ProductPriceGet.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/ProjectStaff.php
+++ b/src/Type/ProjectStaff.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/ProjectStaffGet.php
+++ b/src/Type/ProjectStaffGet.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/PurchaseOrder.php
+++ b/src/Type/PurchaseOrder.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/PurchaseOrderGet.php
+++ b/src/Type/PurchaseOrderGet.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/Revenue.php
+++ b/src/Type/Revenue.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/SalesOrderGet.php
+++ b/src/Type/SalesOrderGet.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/SendShipmentNotification.php
+++ b/src/Type/SendShipmentNotification.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/ShipmentConfirm.php
+++ b/src/Type/ShipmentConfirm.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/Stock.php
+++ b/src/Type/Stock.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/StockAvailable.php
+++ b/src/Type/StockAvailable.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/StockAvailableGet.php
+++ b/src/Type/StockAvailableGet.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/StockGet.php
+++ b/src/Type/StockGet.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/Subscription.php
+++ b/src/Type/Subscription.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/SubscriptionGet.php
+++ b/src/Type/SubscriptionGet.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/TrackingNumber.php
+++ b/src/Type/TrackingNumber.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/TypeInterface.php
+++ b/src/Type/TypeInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type;
 
 /**

--- a/src/Type/Validator/Date.php
+++ b/src/Type/Validator/Date.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type\Validator;
 
 /**

--- a/src/Type/Validator/DateOrEmpty.php
+++ b/src/Type/Validator/DateOrEmpty.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type\Validator;
 
 /**

--- a/src/Type/Validator/TimeInterval.php
+++ b/src/Type/Validator/TimeInterval.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type\Validator;
 
 /**

--- a/src/Type/Validator/ValidatorInterface.php
+++ b/src/Type/Validator/ValidatorInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex\Type\Validator;
 
 /**

--- a/src/TypeFactory.php
+++ b/src/TypeFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MarcusJaschen\Collmex;
 
 use MarcusJaschen\Collmex\Exception\InvalidTypeIdentifierException;


### PR DESCRIPTION
This is the last part of the automatic code cleanup with
php-cs-fixer.