### PR TITLE
[TASK] Add laravel/framework as a dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "symfony/http-foundation": "^2.5.0 || ^3.0.0 || ^4.0.0"
     },
     "require-dev": {
+        "laravel/framework": "^5.4",
         "league/csv": "^8.0 || ^9.0",
         "mockery/mockery": "^1.0",
         "phpunit/phpunit": "^5.7.26",


### PR DESCRIPTION
This makes sure the class `\Illuminate\Support\ServiceProvider` is
defined.