### PR TITLE
[CLEANUP] Shorten overlong lines

### DIFF
--- a/src/Type/AbstractType.php
+++ b/src/Type/AbstractType.php
@@ -136,7 +136,9 @@ abstract class AbstractType implements JsonSerializable
             return $this->data[$name];
         }
 
-        throw new InvalidFieldNameException("Cannot read field value; field '{$name}' does not exist in class " . get_class($this));
+        throw new InvalidFieldNameException(
+            "Cannot read field value; field '{$name}' does not exist in class " . get_class($this)
+        );
     }
 
     /**
@@ -157,7 +159,9 @@ abstract class AbstractType implements JsonSerializable
             return;
         }
 
-        throw new InvalidFieldNameException("Cannot set field value; field '{$name}' does not exist in class " . get_class($this));
+        throw new InvalidFieldNameException(
+            "Cannot set field value; field '{$name}' does not exist in class " . get_class($this)
+        );
     }
 
     /**
@@ -182,7 +186,7 @@ abstract class AbstractType implements JsonSerializable
      */
     protected function populateData($data)
     {
-        if (! isset($data[0])) {
+        if (!isset($data[0])) {
             $this->assertValidFieldNames($data);
             $this->data = array_merge($this->template, $data);
 

--- a/tests/Csv/LeagueCsvGeneratorTest.php
+++ b/tests/Csv/LeagueCsvGeneratorTest.php
@@ -56,7 +56,7 @@ class LeagueCsvGeneratorTest extends \PHPUnit_Framework_TestCase
         ];
 
         $expected = 'TEST;1;a' . "\n"
-                    . 'MESSAGE;E;11111;"Error Message";123' . "\n";
+            . 'MESSAGE;E;11111;"Error Message";123' . "\n";
 
         $this->assertEquals($expected, $this->generator->generate($data));
     }
@@ -94,7 +94,8 @@ class LeagueCsvGeneratorTest extends \PHPUnit_Framework_TestCase
             'Provision Bikemarkt-Verkauf 279679: "Endura MTR Baggy Short // SALE \\\\" an "bebetz" am 1.1.2016',
         ];
 
-        $expected = 'CMXINV;-1001338;"Provision Bikemarkt-Verkauf 279679: ""Endura MTR Baggy Short // SALE \\\\"" an ""bebetz"" am 1.1.2016"' . PHP_EOL;
+        $expected = 'CMXINV;-1001338;"Provision Bikemarkt-Verkauf 279679: ' .
+            '""Endura MTR Baggy Short // SALE \\\\"" an ""bebetz"" am 1.1.2016"' . PHP_EOL;
 
         $this->assertEquals($expected, $this->generator->generate($data));
     }

--- a/tests/Csv/SimpleGeneratorTest.php
+++ b/tests/Csv/SimpleGeneratorTest.php
@@ -56,7 +56,7 @@ class SimpleGeneratorTest extends \PHPUnit_Framework_TestCase
         ];
 
         $expected = 'TEST;1;a' . "\n"
-                    . 'MESSAGE;E;11111;"Error Message";123' . "\n";
+            . 'MESSAGE;E;11111;"Error Message";123' . "\n";
 
         $this->assertEquals($expected, $this->generator->generate($data));
     }
@@ -93,7 +93,8 @@ class SimpleGeneratorTest extends \PHPUnit_Framework_TestCase
             'Provision Bikemarkt-Verkauf 279679: "Endura MTR Baggy Short // SALE \\\\" an "bebetz" am 1.1.2016',
         ];
 
-        $expected = 'CMXINV;-1001338;"Provision Bikemarkt-Verkauf 279679: ""Endura MTR Baggy Short // SALE \\\\"" an ""bebetz"" am 1.1.2016"' . PHP_EOL;
+        $expected = 'CMXINV;-1001338;"Provision Bikemarkt-Verkauf 279679: ' .
+            '""Endura MTR Baggy Short // SALE \\\\"" an ""bebetz"" am 1.1.2016"' . PHP_EOL;
 
         $this->assertEquals($expected, $this->generator->generate($data));
     }


### PR DESCRIPTION
Now all lines are below 120 characters, making the code base
PSR-2-compliant.

Also autoformat the changed files.