### PR TITLE
[CLEANUP] Streamline the `@throws` annotation

### DIFF
--- a/src/Client/Curl.php
+++ b/src/Client/Curl.php
@@ -25,7 +25,7 @@ class Curl extends AbstractClient implements ClientInterface
      *
      * @return string The response body
      *
-     * @throws Exception\RequestFailedException
+     * @throws RequestFailedException
      */
     public function request($body)
     {

--- a/src/Response/ResponseFactory.php
+++ b/src/Response/ResponseFactory.php
@@ -33,8 +33,7 @@ class ResponseFactory
      *
      * @return ZipResponse|CsvResponse
      *
-     * @throws \MarcusJaschen\Collmex\Response\Exception\InvalidZipFileException
-     * @throws \MarcusJaschen\Collmex\Exception\InvalidResponseMimeTypeException
+     * @throws InvalidResponseMimeTypeException
      */
     public function getResponseInstance()
     {

--- a/src/Response/ZipResponse.php
+++ b/src/Response/ZipResponse.php
@@ -87,9 +87,9 @@ class ZipResponse implements ResponseInterface
     }
 
     /**
-     * @throws \MarcusJaschen\Collmex\Response\Exception\InvalidZipFileException
-     *
      * @return void
+     *
+     * @throws InvalidZipFileException
      */
     protected function extractFiles()
     {

--- a/src/Type/AbstractType.php
+++ b/src/Type/AbstractType.php
@@ -126,7 +126,7 @@ abstract class AbstractType implements JsonSerializable
      *
      * @param string $name The field name
      *
-     * @throws \MarcusJaschen\Collmex\Type\Exception\InvalidFieldNameException
+     * @throws InvalidFieldNameException
      *
      * @return mixed
      */
@@ -145,7 +145,7 @@ abstract class AbstractType implements JsonSerializable
      * @param string $name The field name
      * @param mixed $value The new field value
      *
-     * @throws \MarcusJaschen\Collmex\Type\Exception\InvalidFieldNameException
+     * @throws InvalidFieldNameException
      */
     public function __set($name, $value)
     {
@@ -211,7 +211,7 @@ abstract class AbstractType implements JsonSerializable
      *
      * @return void
      *
-     * @throws \MarcusJaschen\Collmex\Type\Exception\InvalidFieldNameException
+     * @throws InvalidFieldNameException
      */
     private function assertValidFieldNames($data)
     {


### PR DESCRIPTION
Now the annotations exactly match the `throw` calls in the methods.