### PR TITLE
[CLEANUP] Remove redundant return from a test case

### DIFF
--- a/tests/Csv/LeagueCsvGeneratorTest.php
+++ b/tests/Csv/LeagueCsvGeneratorTest.php
@@ -86,7 +86,6 @@ class LeagueCsvGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testGenerateCsvWithSpecialCharactersWorksAsExpected()
     {
         $this->markTestSkipped('Skipping test for PHP bug 43225');
-        return;
 
         $data = [
             'CMXINV',


### PR DESCRIPTION
`markTestSkipped` already exits the method. So a return after that
is not needed.