### PR TITLE
[TASK] Drop support for PHP < 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 language: php
 
 php:
-- 5.6
 - 7.0
 - 7.1
 - 7.2

--- a/README.md
+++ b/README.md
@@ -86,16 +86,15 @@ return [
 
 ## Compatibility
 
-The Collmex PHP SDK requires PHP >= 5.6. If you're still using an ancient PHP
+The Collmex PHP SDK requires PHP >= 7.0. If you're still using an ancient PHP
 version, you can install older versions of the Collmex PHP SDK:
 
-- for PHP 5.5 compatibility: use the 0.6.x branch (`composer require mjaschen/collmex:~0.6.0`)
-- for PHP 5.4 compatibility: use the 0.4.x branch (`composer require mjaschen/collmex:~0.4.0`)
-- for PHP 5.3 compatibility: use the 0.3.x branch (`composer require mjaschen/collmex:~0.3.0`)
+- for PHP 5.6 compatibility: use the 0.11.x branch (`composer require mjaschen/collmex:~0.11`)
+- for PHP 5.5 compatibility: use the 0.6.x branch (`composer require mjaschen/collmex:~0.6`)
+- for PHP 5.4 compatibility: use the 0.4.x branch (`composer require mjaschen/collmex:~0.4`)
+- for PHP 5.3 compatibility: use the 0.3.x branch (`composer require mjaschen/collmex:~0.3`)
 
 New features will only go into the master.
-
-Starting early 2019, the Collmex PHP SDK will require at least PHP 7.0.
 
 ## Usage/Examples
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "issues": "https://github.com/mjaschen/collmex/issues"
     },
     "require": {
-        "php": "^5.6.0 || ~7.0.0 || ~7.1.0 || ~7.2.0 || ~7.3.0",
+        "php": "~7.0 || ~7.1 || ~7.2 || ~7.3",
         "ext-curl": "*",
         "ext-json": "*",
         "ext-zip": "*",
@@ -29,7 +29,7 @@
     },
     "require-dev": {
         "laravel/framework": "^5.4",
-        "league/csv": "^8.0 || ^9.0",
+        "league/csv": "^9.1",
         "mockery/mockery": "^1.0",
         "phpunit/phpunit": "^5.7.26",
         "roave/security-advisories": "dev-master",


### PR DESCRIPTION
This commit is only about updating the requirements.

Using PHP 7 features and re-enabled Psalm will go into separate commits.

Closes #104