### PR TITLE
[CLEANUP] Reorder the dev dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 language: php
 
 php:
-- 5.6
 - 7.0
 - 7.1
 - 7.2

--- a/composer.json
+++ b/composer.json
@@ -32,9 +32,9 @@
         "league/csv": "^8.0 || ^9.0",
         "mockery/mockery": "^1.0",
         "phpunit/phpunit": "^5.7.26",
-        "roave/security-advisories": "dev-master",
         "vimeo/psalm": "^2.0",
-        "squizlabs/php_codesniffer": "~3.0"
+        "squizlabs/php_codesniffer": "~3.0",
+        "roave/security-advisories": "dev-master"
     },
     "suggest": {
         "league/csv": "Enable CSV generation via the 'Csv' library by The PHP League"


### PR DESCRIPTION
Move `roave/security-advisories` to the bottom as this dependency
is different to the other dependencies: It does not provide code,
but blocks insecure versions from being installed.

In addition, keeping this dependency at the bottom allows other
dependencies being removed or added without have to care about
trailing commas after arrays in the composer.json.

This PR should only be merged after #106 has been merged.