### PR TITLE
[CLEANUP] Shorten the composer install in the TravisCI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 language: php
 
 php:
-- 5.6
 - 7.0
 - 7.1
 - 7.2
@@ -26,10 +25,10 @@ install:
   echo;
   if [ "$DEPENDENCIES" = "latest" ]; then
     echo "Installing the latest dependencies";
-    composer update --with-dependencies --prefer-stable --prefer-dist
+    composer update --with-dependencies
   else
     echo "Installing the lowest dependencies";
-    composer update --with-dependencies --prefer-stable --prefer-dist --prefer-lowest
+    composer update --with-dependencies --prefer-lowest
   fi;
   composer show;
 

--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,12 @@
             "MarcusJaschen\\Collmex\\Tests\\": "tests/"
         }
     },
+    "prefer-stable": true,
+    "config": {
+        "preferred-install": {
+            "*": "dist"
+        }
+    },
     "scripts": {
         "ci:lint": "find config src tests -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l",
         "ci:sniff": "./vendor/bin/phpcs --standard=PSR1,PSR2,PSR12 src/ tests/",


### PR DESCRIPTION
Now the settings `prefer stable` and `prefer dist` are located in the
`composer.json`, not as command-line argument to `composer update` anymore.

This only affects when using the package stand-alone (i.e., during development),
not when the package is used as a dependency.

This PR should only be merged after #106 has been merged.