### PR TITLE
[CLEANUP] Use shorter version constraints in the composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,9 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-zip": "*",
-        "neitanod/forceutf8": "^1.4.0 || ^2.0.0",
-        "symfony/finder": "^2.5.0 || ^3.0.0 || ^4.0.0",
-        "symfony/http-foundation": "^2.5.0 || ^3.0.0 || ^4.0.0"
+        "neitanod/forceutf8": "^1.4 || ^2.0",
+        "symfony/finder": "^2.5 || ^3.0 || ^4.0",
+        "symfony/http-foundation": "^2.5 || ^3.0 || ^4.0"
     },
     "require-dev": {
         "laravel/framework": "^5.4",


### PR DESCRIPTION
For example, `^2.0` is just as good as `^2.0.0`, but more succinct.