### PR TITLE
[TASK] Raise the production dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,9 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-zip": "*",
-        "neitanod/forceutf8": "^1.4 || ^2.0",
-        "symfony/finder": "^2.5 || ^3.0 || ^4.0",
-        "symfony/http-foundation": "^2.5 || ^3.0 || ^4.0"
+        "neitanod/forceutf8": "^2.0",
+        "symfony/finder": "^4.0",
+        "symfony/http-foundation": "^4.0"
     },
     "require-dev": {
         "laravel/framework": "^5.4",


### PR DESCRIPTION
Now the dependencies are:
- "neitanod/forceutf8": "^2.0",
- "symfony/finder": "^4.0",
- "symfony/http-foundation": "^4.0"

This is a breaking change for projects that still use older version of these
libraries.

Closes #117