### PR TITLE
[TASK] Raise the dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,12 +28,12 @@
         "symfony/http-foundation": "^2.5 || ^3.0 || ^4.0"
     },
     "require-dev": {
-        "laravel/framework": "^5.4",
+        "laravel/framework": "^5.8",
         "league/csv": "^9.1",
-        "mockery/mockery": "^1.0",
+        "mockery/mockery": "^1.2",
         "phpunit/phpunit": "^5.7.26",
-        "vimeo/psalm": "^3.0",
-        "squizlabs/php_codesniffer": "~3.4",
+        "vimeo/psalm": "^3.1",
+        "squizlabs/php_codesniffer": "^3.4",
         "roave/security-advisories": "dev-master"
     },
     "suggest": {


### PR DESCRIPTION
Now all dependencies (except for PHPUnit, which will be a separate change)
are at their current major release.

This does not affect projects using `mjaschen/collmex` as a dependency.