### PR TITLE
[CLEANUP] Streamline setUp and tearDown in the tests

### DIFF
--- a/tests/Csv/LeagueCsvGeneratorTest.php
+++ b/tests/Csv/LeagueCsvGeneratorTest.php
@@ -11,14 +11,9 @@ class LeagueCsvGeneratorTest extends \PHPUnit_Framework_TestCase
      */
     protected $generator;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->generator = new LeagueCsvGenerator(';', '"');
-    }
-
-    public function tearDown()
-    {
-        unset($this->generator);
     }
 
     public function testGenerateCsvOneLine()

--- a/tests/Csv/LeagueCsvParserTest.php
+++ b/tests/Csv/LeagueCsvParserTest.php
@@ -11,14 +11,9 @@ class LeagueCsvParserTest extends \PHPUnit_Framework_TestCase
      */
     protected $parser;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->parser = new LeagueCsvParser(';', '"');
-    }
-
-    public function tearDown()
-    {
-        unset($this->parser);
     }
 
     public function testParseOneLine()

--- a/tests/Csv/SimpleGeneratorTest.php
+++ b/tests/Csv/SimpleGeneratorTest.php
@@ -11,14 +11,9 @@ class SimpleGeneratorTest extends \PHPUnit_Framework_TestCase
      */
     protected $generator;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->generator = new SimpleGenerator(';', '"');
-    }
-
-    public function tearDown()
-    {
-        unset($this->generator);
     }
 
     public function testGenerateCsvOneLine()

--- a/tests/Csv/SimpleParserTest.php
+++ b/tests/Csv/SimpleParserTest.php
@@ -9,14 +9,9 @@ class SimpleParserTest extends \PHPUnit_Framework_TestCase
      */
     protected $parser;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->parser = new \MarcusJaschen\Collmex\Csv\SimpleParser(';', '"');
-    }
-
-    public function tearDown()
-    {
-        unset($this->parser);
     }
 
     public function testParseOneLine()

--- a/tests/Filter/Utf8ToWindows1252Test.php
+++ b/tests/Filter/Utf8ToWindows1252Test.php
@@ -11,14 +11,9 @@ class Utf8ToWindows1252Test extends \PHPUnit_Framework_TestCase
      */
     protected $filter;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->filter = new Utf8ToWindows1252();
-    }
-
-    public function tearDown()
-    {
-        unset($this->filter);
     }
 
     public function testEncodeString()

--- a/tests/Filter/Windows1252ToUtf8Test.php
+++ b/tests/Filter/Windows1252ToUtf8Test.php
@@ -11,14 +11,9 @@ class Windows1252ToUtf8Test extends \PHPUnit_Framework_TestCase
      */
     protected $filter;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->filter = new Windows1252ToUtf8();
-    }
-
-    public function tearDown()
-    {
-        unset($this->filter);
     }
 
     public function testEncodeString()

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -8,7 +8,7 @@ use Mockery as m;
 
 class ResponseTest extends \PHPUnit_Framework_TestCase
 {
-    public function tearDown()
+    protected function tearDown()
     {
         m::close();
     }

--- a/tests/Type/SubscriptionTest.php
+++ b/tests/Type/SubscriptionTest.php
@@ -11,7 +11,7 @@ class SubscriptionTest extends \PHPUnit_Framework_TestCase
      */
     protected $type;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->type = new Subscription(
             [
@@ -26,11 +26,6 @@ class SubscriptionTest extends \PHPUnit_Framework_TestCase
                 'next_invoice'        => null,
             ]
         );
-    }
-
-    public function tearDown()
-    {
-        unset($this->type);
     }
 
     public function testValidateSuccess()

--- a/tests/Type/Validator/DateOrEmptyTest.php
+++ b/tests/Type/Validator/DateOrEmptyTest.php
@@ -9,14 +9,9 @@ class DateOrEmptyTest extends \PHPUnit_Framework_TestCase
      */
     protected $validator;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->validator = new \MarcusJaschen\Collmex\Type\Validator\DateOrEmpty();
-    }
-
-    public function tearDown()
-    {
-        unset($this->validator);
     }
 
     public function testValidDate()

--- a/tests/Type/Validator/DateTest.php
+++ b/tests/Type/Validator/DateTest.php
@@ -9,14 +9,9 @@ class DateTest extends \PHPUnit_Framework_TestCase
      */
     protected $validator;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->validator = new \MarcusJaschen\Collmex\Type\Validator\Date();
-    }
-
-    public function tearDown()
-    {
-        unset($this->validator);
     }
 
     public function testValidDate()

--- a/tests/Type/Validator/TimeIntervalTest.php
+++ b/tests/Type/Validator/TimeIntervalTest.php
@@ -12,14 +12,9 @@ class TimeIntervalTest extends \PHPUnit_Framework_TestCase
      */
     protected $validator;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->validator = new TimeInterval();
-    }
-
-    public function tearDown()
-    {
-        unset($this->validator);
     }
 
     public function testValidTimeInterval()

--- a/tests/TypeFactoryTest.php
+++ b/tests/TypeFactoryTest.php
@@ -14,14 +14,9 @@ class TypeFactoryTest extends \PHPUnit_Framework_TestCase
      */
     protected $typeFactory;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->typeFactory = new TypeFactory();
-    }
-
-    public function tearDown()
-    {
-        unset($this->typeFactory);
     }
 
     public function testCreateCustomerTypeSuccessful()


### PR DESCRIPTION
- Make `setUp` and `tearDown` protected as the corresponding methods
  in the base class are protected as well, and there is no need to
  make these methods public.

- Delete `tearDown` methods that do nothing else than unset the
  subject. Current versions of PHP do not need this anymore for
  the garbage collector.