### PR TITLE
[CLEANUP] Use strict checks in the unit tests

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -147,7 +147,7 @@ $rules = [
     'php_unit_no_expectation_annotation' => true,
     'php_unit_ordered_covers' => true,
     'php_unit_set_up_tear_down_visibility' => true,
-//    'php_unit_strict' => true,
+    'php_unit_strict' => true,
 //    'php_unit_test_case_static_method_calls' => ['call_type' => 'self'],
     'protected_to_private' => true,
     'psr4' => true,

--- a/tests/Csv/LeagueCsvGeneratorTest.php
+++ b/tests/Csv/LeagueCsvGeneratorTest.php
@@ -31,7 +31,7 @@ class LeagueCsvGeneratorTest extends TestCase
 
         $expected = 'MESSAGE;E;11111;"Error Message";123' . "\n";
 
-        $this->assertEquals($expected, $this->generator->generate($data));
+        $this->assertSame($expected, $this->generator->generate($data));
     }
 
     public function testGenerateCsvMultipleLines()
@@ -54,7 +54,7 @@ class LeagueCsvGeneratorTest extends TestCase
         $expected = 'TEST;1;a' . "\n"
             . 'MESSAGE;E;11111;"Error Message";123' . "\n";
 
-        $this->assertEquals($expected, $this->generator->generate($data));
+        $this->assertSame($expected, $this->generator->generate($data));
     }
 
     public function testGenerateCsvOneLineWithoutOuterArray()
@@ -69,7 +69,7 @@ class LeagueCsvGeneratorTest extends TestCase
 
         $expected = 'MESSAGE;E;11111;"Error Message";123' . "\n";
 
-        $this->assertEquals($expected, $this->generator->generate($data));
+        $this->assertSame($expected, $this->generator->generate($data));
     }
 
     /**
@@ -92,6 +92,6 @@ class LeagueCsvGeneratorTest extends TestCase
         $expected = 'CMXINV;-1001338;"Provision Bikemarkt-Verkauf 279679: ' .
             '""Endura MTR Baggy Short // SALE \\\\"" an ""bebetz"" am 1.1.2016"' . PHP_EOL;
 
-        $this->assertEquals($expected, $this->generator->generate($data));
+        $this->assertSame($expected, $this->generator->generate($data));
     }
 }

--- a/tests/Csv/LeagueCsvParserTest.php
+++ b/tests/Csv/LeagueCsvParserTest.php
@@ -31,7 +31,7 @@ class LeagueCsvParserTest extends TestCase
             ],
         ];
 
-        $this->assertEquals($expected, $data);
+        $this->assertSame($expected, $data);
     }
 
     public function testParseOneLineWithNewline()
@@ -48,7 +48,7 @@ class LeagueCsvParserTest extends TestCase
             ],
         ];
 
-        $this->assertEquals($expected, $data);
+        $this->assertSame($expected, $data);
     }
 
     public function testParseMultipleLines()
@@ -65,11 +65,11 @@ class LeagueCsvParserTest extends TestCase
             ],
             [
                 'CMXINV',
-                100,
-                1,
+                '100',
+                '1',
             ],
         ];
 
-        $this->assertEquals($expected, $data);
+        $this->assertSame($expected, $data);
     }
 }

--- a/tests/Csv/SimpleGeneratorTest.php
+++ b/tests/Csv/SimpleGeneratorTest.php
@@ -31,7 +31,7 @@ class SimpleGeneratorTest extends TestCase
 
         $expected = 'MESSAGE;E;11111;"Error Message";123' . "\n";
 
-        $this->assertEquals($expected, $this->generator->generate($data));
+        $this->assertSame($expected, $this->generator->generate($data));
     }
 
     public function testGenerateCsvMultipleLines()
@@ -54,7 +54,7 @@ class SimpleGeneratorTest extends TestCase
         $expected = 'TEST;1;a' . "\n"
             . 'MESSAGE;E;11111;"Error Message";123' . "\n";
 
-        $this->assertEquals($expected, $this->generator->generate($data));
+        $this->assertSame($expected, $this->generator->generate($data));
     }
 
     public function testGenerateCsvOneLineWithoutOuterArray()
@@ -69,7 +69,7 @@ class SimpleGeneratorTest extends TestCase
 
         $expected = 'MESSAGE;E;11111;"Error Message";123' . "\n";
 
-        $this->assertEquals($expected, $this->generator->generate($data));
+        $this->assertSame($expected, $this->generator->generate($data));
     }
 
     /**
@@ -92,6 +92,6 @@ class SimpleGeneratorTest extends TestCase
         $expected = 'CMXINV;-1001338;"Provision Bikemarkt-Verkauf 279679: ' .
             '""Endura MTR Baggy Short // SALE \\\\"" an ""bebetz"" am 1.1.2016"' . PHP_EOL;
 
-        $this->assertEquals($expected, $this->generator->generate($data));
+        $this->assertSame($expected, $this->generator->generate($data));
     }
 }

--- a/tests/Csv/SimpleParserTest.php
+++ b/tests/Csv/SimpleParserTest.php
@@ -30,7 +30,7 @@ class SimpleParserTest extends TestCase
             ],
         ];
 
-        $this->assertEquals($expected, $data);
+        $this->assertSame($expected, $data);
     }
 
     public function testParseOneLineWithNewline()
@@ -47,7 +47,7 @@ class SimpleParserTest extends TestCase
             ],
         ];
 
-        $this->assertEquals($expected, $data);
+        $this->assertSame($expected, $data);
     }
 
     public function testParseMultipleLines()
@@ -64,11 +64,11 @@ class SimpleParserTest extends TestCase
             ],
             [
                 'CMXINV',
-                100,
-                1,
+                '100',
+                '1',
             ],
         ];
 
-        $this->assertEquals($expected, $data);
+        $this->assertSame($expected, $data);
     }
 }

--- a/tests/Filter/Utf8ToWindows1252Test.php
+++ b/tests/Filter/Utf8ToWindows1252Test.php
@@ -22,7 +22,7 @@ class Utf8ToWindows1252Test extends TestCase
         $input = file_get_contents(__DIR__ . DIRECTORY_SEPARATOR . '_fixtures' . DIRECTORY_SEPARATOR . 'utf-8.txt');
         $expected = file_get_contents(__DIR__ . DIRECTORY_SEPARATOR . '_fixtures' . DIRECTORY_SEPARATOR . 'cp1252.txt');
 
-        $this->assertEquals($expected, $this->filter->filterString($input));
+        $this->assertSame($expected, $this->filter->filterString($input));
     }
 
     public function testEncodeArray()
@@ -40,7 +40,7 @@ class Utf8ToWindows1252Test extends TestCase
             $target,
         ];
 
-        $this->assertEquals($expected, $this->filter->filterArray($input));
+        $this->assertSame($expected, $this->filter->filterArray($input));
     }
 
     public function testEncodeArrayRecursive()
@@ -62,6 +62,6 @@ class Utf8ToWindows1252Test extends TestCase
             $target,
         ];
 
-        $this->assertEquals($expected, $this->filter->filterArray($input));
+        $this->assertSame($expected, $this->filter->filterArray($input));
     }
 }

--- a/tests/Filter/Windows1252ToUtf8Test.php
+++ b/tests/Filter/Windows1252ToUtf8Test.php
@@ -22,7 +22,7 @@ class Windows1252ToUtf8Test extends TestCase
         $input    = file_get_contents(__DIR__ . DIRECTORY_SEPARATOR . '_fixtures' . DIRECTORY_SEPARATOR . 'cp1252.txt');
         $expected = file_get_contents(__DIR__ . DIRECTORY_SEPARATOR . '_fixtures' . DIRECTORY_SEPARATOR . 'utf-8.txt');
 
-        $this->assertEquals($expected, $this->filter->filterString($input));
+        $this->assertSame($expected, $this->filter->filterString($input));
     }
 
     public function testEncodeArray()
@@ -40,7 +40,7 @@ class Windows1252ToUtf8Test extends TestCase
             $target,
         ];
 
-        $this->assertEquals($expected, $this->filter->filterArray($input));
+        $this->assertSame($expected, $this->filter->filterArray($input));
     }
 
     public function testEncodeArrayRecursive()
@@ -62,6 +62,6 @@ class Windows1252ToUtf8Test extends TestCase
             $target,
         ];
 
-        $this->assertEquals($expected, $this->filter->filterArray($input));
+        $this->assertSame($expected, $this->filter->filterArray($input));
     }
 }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -37,9 +37,9 @@ class ResponseTest extends TestCase
         $response = new CsvResponse($parser, $responseBody);
 
         $this->assertTrue($response->isError());
-        $this->assertEquals('Error Message', $response->getErrorMessage());
-        $this->assertEquals('11111', $response->getErrorCode());
-        $this->assertEquals(1, $response->getErrorLine());
+        $this->assertSame('Error Message', $response->getErrorMessage());
+        $this->assertSame('11111', $response->getErrorCode());
+        $this->assertSame(1, $response->getErrorLine());
 
         // check again (but don't parse again)
         $this->assertTrue($response->isError());


### PR DESCRIPTION
This will also catch type mismatches.