### PR TITLE
[CLEANUP] Always use self:: for calling the PHPUnit assertions

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -148,7 +148,7 @@ $rules = [
     'php_unit_ordered_covers' => true,
     'php_unit_set_up_tear_down_visibility' => true,
     'php_unit_strict' => true,
-//    'php_unit_test_case_static_method_calls' => ['call_type' => 'self'],
+    'php_unit_test_case_static_method_calls' => ['call_type' => 'self'],
     'protected_to_private' => true,
     'psr4' => true,
     'return_type_declaration' => true,

--- a/tests/Unit/Csv/LeagueCsvGeneratorTest.php
+++ b/tests/Unit/Csv/LeagueCsvGeneratorTest.php
@@ -32,7 +32,7 @@ class LeagueCsvGeneratorTest extends TestCase
 
         $expected = 'MESSAGE;E;11111;"Error Message";123' . "\n";
 
-        $this->assertSame($expected, $this->generator->generate($data));
+        self::assertSame($expected, $this->generator->generate($data));
     }
 
     public function testGenerateCsvMultipleLines(): void
@@ -55,7 +55,7 @@ class LeagueCsvGeneratorTest extends TestCase
         $expected = 'TEST;1;a' . "\n"
             . 'MESSAGE;E;11111;"Error Message";123' . "\n";
 
-        $this->assertSame($expected, $this->generator->generate($data));
+        self::assertSame($expected, $this->generator->generate($data));
     }
 
     public function testGenerateCsvOneLineWithoutOuterArray(): void
@@ -70,7 +70,7 @@ class LeagueCsvGeneratorTest extends TestCase
 
         $expected = 'MESSAGE;E;11111;"Error Message";123' . "\n";
 
-        $this->assertSame($expected, $this->generator->generate($data));
+        self::assertSame($expected, $this->generator->generate($data));
     }
 
     /**
@@ -82,7 +82,7 @@ class LeagueCsvGeneratorTest extends TestCase
      */
     public function testGenerateCsvWithSpecialCharactersWorksAsExpected(): void
     {
-        $this->markTestSkipped('Skipping test for PHP bug 43225');
+        self::markTestSkipped('Skipping test for PHP bug 43225');
 
         $data = [
             'CMXINV',
@@ -93,6 +93,6 @@ class LeagueCsvGeneratorTest extends TestCase
         $expected = 'CMXINV;-1001338;"Provision Bikemarkt-Verkauf 279679: ' .
             '""Endura MTR Baggy Short // SALE \\\\"" an ""bebetz"" am 1.1.2016"' . PHP_EOL;
 
-        $this->assertSame($expected, $this->generator->generate($data));
+        self::assertSame($expected, $this->generator->generate($data));
     }
 }

--- a/tests/Unit/Csv/LeagueCsvParserTest.php
+++ b/tests/Unit/Csv/LeagueCsvParserTest.php
@@ -32,7 +32,7 @@ class LeagueCsvParserTest extends TestCase
             ],
         ];
 
-        $this->assertSame($expected, $data);
+        self::assertSame($expected, $data);
     }
 
     public function testParseOneLineWithNewline(): void
@@ -49,7 +49,7 @@ class LeagueCsvParserTest extends TestCase
             ],
         ];
 
-        $this->assertSame($expected, $data);
+        self::assertSame($expected, $data);
     }
 
     public function testParseMultipleLines(): void
@@ -71,6 +71,6 @@ class LeagueCsvParserTest extends TestCase
             ],
         ];
 
-        $this->assertSame($expected, $data);
+        self::assertSame($expected, $data);
     }
 }

--- a/tests/Unit/Csv/SimpleGeneratorTest.php
+++ b/tests/Unit/Csv/SimpleGeneratorTest.php
@@ -32,7 +32,7 @@ class SimpleGeneratorTest extends TestCase
 
         $expected = 'MESSAGE;E;11111;"Error Message";123' . "\n";
 
-        $this->assertSame($expected, $this->generator->generate($data));
+        self::assertSame($expected, $this->generator->generate($data));
     }
 
     public function testGenerateCsvMultipleLines(): void
@@ -55,7 +55,7 @@ class SimpleGeneratorTest extends TestCase
         $expected = 'TEST;1;a' . "\n"
             . 'MESSAGE;E;11111;"Error Message";123' . "\n";
 
-        $this->assertSame($expected, $this->generator->generate($data));
+        self::assertSame($expected, $this->generator->generate($data));
     }
 
     public function testGenerateCsvOneLineWithoutOuterArray(): void
@@ -70,7 +70,7 @@ class SimpleGeneratorTest extends TestCase
 
         $expected = 'MESSAGE;E;11111;"Error Message";123' . "\n";
 
-        $this->assertSame($expected, $this->generator->generate($data));
+        self::assertSame($expected, $this->generator->generate($data));
     }
 
     /**
@@ -93,6 +93,6 @@ class SimpleGeneratorTest extends TestCase
         $expected = 'CMXINV;-1001338;"Provision Bikemarkt-Verkauf 279679: ' .
             '""Endura MTR Baggy Short // SALE \\\\"" an ""bebetz"" am 1.1.2016"' . PHP_EOL;
 
-        $this->assertSame($expected, $this->generator->generate($data));
+        self::assertSame($expected, $this->generator->generate($data));
     }
 }

--- a/tests/Unit/Csv/SimpleParserTest.php
+++ b/tests/Unit/Csv/SimpleParserTest.php
@@ -31,7 +31,7 @@ class SimpleParserTest extends TestCase
             ],
         ];
 
-        $this->assertSame($expected, $data);
+        self::assertSame($expected, $data);
     }
 
     public function testParseOneLineWithNewline(): void
@@ -48,7 +48,7 @@ class SimpleParserTest extends TestCase
             ],
         ];
 
-        $this->assertSame($expected, $data);
+        self::assertSame($expected, $data);
     }
 
     public function testParseMultipleLines(): void
@@ -70,6 +70,6 @@ class SimpleParserTest extends TestCase
             ],
         ];
 
-        $this->assertSame($expected, $data);
+        self::assertSame($expected, $data);
     }
 }

--- a/tests/Unit/Filter/Utf8ToWindows1252Test.php
+++ b/tests/Unit/Filter/Utf8ToWindows1252Test.php
@@ -23,7 +23,7 @@ class Utf8ToWindows1252Test extends TestCase
         $input = file_get_contents(__DIR__ . DIRECTORY_SEPARATOR . '_fixtures' . DIRECTORY_SEPARATOR . 'utf-8.txt');
         $expected = file_get_contents(__DIR__ . DIRECTORY_SEPARATOR . '_fixtures' . DIRECTORY_SEPARATOR . 'cp1252.txt');
 
-        $this->assertSame($expected, $this->filter->filterString($input));
+        self::assertSame($expected, $this->filter->filterString($input));
     }
 
     public function testEncodeArray(): void
@@ -41,7 +41,7 @@ class Utf8ToWindows1252Test extends TestCase
             $target,
         ];
 
-        $this->assertSame($expected, $this->filter->filterArray($input));
+        self::assertSame($expected, $this->filter->filterArray($input));
     }
 
     public function testEncodeArrayRecursive(): void
@@ -63,6 +63,6 @@ class Utf8ToWindows1252Test extends TestCase
             $target,
         ];
 
-        $this->assertSame($expected, $this->filter->filterArray($input));
+        self::assertSame($expected, $this->filter->filterArray($input));
     }
 }

--- a/tests/Unit/Filter/Windows1252ToUtf8Test.php
+++ b/tests/Unit/Filter/Windows1252ToUtf8Test.php
@@ -23,7 +23,7 @@ class Windows1252ToUtf8Test extends TestCase
         $input = file_get_contents(__DIR__ . DIRECTORY_SEPARATOR . '_fixtures' . DIRECTORY_SEPARATOR . 'cp1252.txt');
         $expected = file_get_contents(__DIR__ . DIRECTORY_SEPARATOR . '_fixtures' . DIRECTORY_SEPARATOR . 'utf-8.txt');
 
-        $this->assertSame($expected, $this->filter->filterString($input));
+        self::assertSame($expected, $this->filter->filterString($input));
     }
 
     public function testEncodeArray(): void
@@ -41,7 +41,7 @@ class Windows1252ToUtf8Test extends TestCase
             $target,
         ];
 
-        $this->assertSame($expected, $this->filter->filterArray($input));
+        self::assertSame($expected, $this->filter->filterArray($input));
     }
 
     public function testEncodeArrayRecursive(): void
@@ -63,6 +63,6 @@ class Windows1252ToUtf8Test extends TestCase
             $target,
         ];
 
-        $this->assertSame($expected, $this->filter->filterArray($input));
+        self::assertSame($expected, $this->filter->filterArray($input));
     }
 }

--- a/tests/Unit/ResponseTest.php
+++ b/tests/Unit/ResponseTest.php
@@ -37,13 +37,13 @@ class ResponseTest extends TestCase
 
         $response = new CsvResponse($parser, $responseBody);
 
-        $this->assertTrue($response->isError());
-        $this->assertSame('Error Message', $response->getErrorMessage());
-        $this->assertSame('11111', $response->getErrorCode());
-        $this->assertSame(1, $response->getErrorLine());
+        self::assertTrue($response->isError());
+        self::assertSame('Error Message', $response->getErrorMessage());
+        self::assertSame('11111', $response->getErrorCode());
+        self::assertSame(1, $response->getErrorLine());
 
         // check again (but don't parse again)
-        $this->assertTrue($response->isError());
+        self::assertTrue($response->isError());
     }
 
     public function testIsErrorWhenNoErrorWorksAsExpected(): void
@@ -67,8 +67,8 @@ class ResponseTest extends TestCase
 
         $response = new CsvResponse($parser, $responseBody);
 
-        $this->assertFalse($response->isError());
-        $this->assertNull($response->getErrorMessage());
-        $this->assertNull($response->getErrorCode());
+        self::assertFalse($response->isError());
+        self::assertNull($response->getErrorMessage());
+        self::assertNull($response->getErrorCode());
     }
 }

--- a/tests/Unit/Type/SubscriptionTest.php
+++ b/tests/Unit/Type/SubscriptionTest.php
@@ -54,27 +54,27 @@ class SubscriptionTest extends TestCase
 
     public function testValidateSuccess(): void
     {
-        $this->assertTrue($this->type->validate());
+        self::assertTrue($this->type->validate());
     }
 
     public function testValidateFailInvalidFromDate(): void
     {
         $this->type->valid_from = '21250101';
 
-        $this->assertFalse($this->type->validate());
+        self::assertFalse($this->type->validate());
     }
 
     public function testValidateFailInvalidToDate(): void
     {
         $this->type->valid_to = '21250101';
 
-        $this->assertFalse($this->type->validate());
+        self::assertFalse($this->type->validate());
     }
 
     public function testValidateFailInvalidInterval(): void
     {
         $this->type->interval = -1;
 
-        $this->assertFalse($this->type->validate());
+        self::assertFalse($this->type->validate());
     }
 }

--- a/tests/Unit/Type/Validator/DateOrEmptyTest.php
+++ b/tests/Unit/Type/Validator/DateOrEmptyTest.php
@@ -19,39 +19,39 @@ class DateOrEmptyTest extends TestCase
 
     public function testValidDate(): void
     {
-        $this->assertTrue($this->validator->validate('20130916'));
+        self::assertTrue($this->validator->validate('20130916'));
     }
 
     public function testEmptyValue(): void
     {
-        $this->assertTrue($this->validator->validate(''));
+        self::assertTrue($this->validator->validate(''));
     }
 
     public function testInvalidDateTooShort(): void
     {
-        $this->assertFalse($this->validator->validate('2013'));
+        self::assertFalse($this->validator->validate('2013'));
     }
 
     public function testInvalidDateTooLong(): void
     {
-        $this->assertFalse($this->validator->validate('20130916100000'));
+        self::assertFalse($this->validator->validate('20130916100000'));
     }
 
     public function testInvalidYear(): void
     {
-        $this->assertFalse($this->validator->validate('18230901'));
-        $this->assertFalse($this->validator->validate('21250901'));
+        self::assertFalse($this->validator->validate('18230901'));
+        self::assertFalse($this->validator->validate('21250901'));
     }
 
     public function testInvalidMonth(): void
     {
-        $this->assertFalse($this->validator->validate('20130001'));
-        $this->assertFalse($this->validator->validate('20131301'));
+        self::assertFalse($this->validator->validate('20130001'));
+        self::assertFalse($this->validator->validate('20131301'));
     }
 
     public function testInvalidDay(): void
     {
-        $this->assertFalse($this->validator->validate('20130900'));
-        $this->assertFalse($this->validator->validate('20130932'));
+        self::assertFalse($this->validator->validate('20130900'));
+        self::assertFalse($this->validator->validate('20130932'));
     }
 }

--- a/tests/Unit/Type/Validator/DateTest.php
+++ b/tests/Unit/Type/Validator/DateTest.php
@@ -19,34 +19,34 @@ class DateTest extends TestCase
 
     public function testValidDate(): void
     {
-        $this->assertTrue($this->validator->validate('20130916'));
+        self::assertTrue($this->validator->validate('20130916'));
     }
 
     public function testInvalidDateTooShort(): void
     {
-        $this->assertFalse($this->validator->validate('2013'));
+        self::assertFalse($this->validator->validate('2013'));
     }
 
     public function testInvalidDateTooLong(): void
     {
-        $this->assertFalse($this->validator->validate('20130916100000'));
+        self::assertFalse($this->validator->validate('20130916100000'));
     }
 
     public function testInvalidYear(): void
     {
-        $this->assertFalse($this->validator->validate('18230901'));
-        $this->assertFalse($this->validator->validate('21250901'));
+        self::assertFalse($this->validator->validate('18230901'));
+        self::assertFalse($this->validator->validate('21250901'));
     }
 
     public function testInvalidMonth(): void
     {
-        $this->assertFalse($this->validator->validate('20130001'));
-        $this->assertFalse($this->validator->validate('20131301'));
+        self::assertFalse($this->validator->validate('20130001'));
+        self::assertFalse($this->validator->validate('20131301'));
     }
 
     public function testInvalidDay(): void
     {
-        $this->assertFalse($this->validator->validate('20130900'));
-        $this->assertFalse($this->validator->validate('20130932'));
+        self::assertFalse($this->validator->validate('20130900'));
+        self::assertFalse($this->validator->validate('20130932'));
     }
 }

--- a/tests/Unit/Type/Validator/TimeIntervalTest.php
+++ b/tests/Unit/Type/Validator/TimeIntervalTest.php
@@ -21,22 +21,22 @@ class TimeIntervalTest extends TestCase
 
     public function testValidTimeInterval(): void
     {
-        $this->assertTrue($this->validator->validate(Subscription::INTERVAL_YEAR));
-        $this->assertTrue($this->validator->validate(Subscription::INTERVAL_HALF_YEAR));
-        $this->assertTrue($this->validator->validate(Subscription::INTERVAL_QUARTER));
-        $this->assertTrue($this->validator->validate(Subscription::INTERVAL_MONTH));
-        $this->assertTrue($this->validator->validate(Subscription::INTERVAL_YEAR_PREPAID));
-        $this->assertTrue($this->validator->validate(Subscription::INTERVAL_HALF_YEAR_PREPAID));
-        $this->assertTrue($this->validator->validate(Subscription::INTERVAL_QUARTER_PREPAID));
-        $this->assertTrue($this->validator->validate(Subscription::INTERVAL_MONTH_PREPAID));
+        self::assertTrue($this->validator->validate(Subscription::INTERVAL_YEAR));
+        self::assertTrue($this->validator->validate(Subscription::INTERVAL_HALF_YEAR));
+        self::assertTrue($this->validator->validate(Subscription::INTERVAL_QUARTER));
+        self::assertTrue($this->validator->validate(Subscription::INTERVAL_MONTH));
+        self::assertTrue($this->validator->validate(Subscription::INTERVAL_YEAR_PREPAID));
+        self::assertTrue($this->validator->validate(Subscription::INTERVAL_HALF_YEAR_PREPAID));
+        self::assertTrue($this->validator->validate(Subscription::INTERVAL_QUARTER_PREPAID));
+        self::assertTrue($this->validator->validate(Subscription::INTERVAL_MONTH_PREPAID));
     }
 
     public function testInvalidTimeInterval(): void
     {
-        $this->assertFalse($this->validator->validate(-1));
-        $this->assertFalse($this->validator->validate(8));
-        $this->assertFalse($this->validator->validate('Foo'));
-        $this->assertFalse($this->validator->validate(false));
-        $this->assertFalse($this->validator->validate(null));
+        self::assertFalse($this->validator->validate(-1));
+        self::assertFalse($this->validator->validate(8));
+        self::assertFalse($this->validator->validate('Foo'));
+        self::assertFalse($this->validator->validate(false));
+        self::assertFalse($this->validator->validate(null));
     }
 }

--- a/tests/Unit/TypeFactoryTest.php
+++ b/tests/Unit/TypeFactoryTest.php
@@ -35,7 +35,7 @@ class TypeFactoryTest extends TestCase
 
         $type = $this->typeFactory->getType($data);
 
-        $this->assertInstanceOf(Customer::class, $type);
+        self::assertInstanceOf(Customer::class, $type);
     }
 
     public function testCreateSubscriptionTypeSuccessful(): void
@@ -55,7 +55,7 @@ class TypeFactoryTest extends TestCase
 
         $type = $this->typeFactory->getType($data);
 
-        $this->assertInstanceOf(Subscription::class, $type);
+        self::assertInstanceOf(Subscription::class, $type);
     }
 
     public function testCreateRevenueTypeWorksAsExpected(): void
@@ -80,7 +80,7 @@ class TypeFactoryTest extends TestCase
 
         $type = $this->typeFactory->getType($data);
 
-        $this->assertInstanceOf(Revenue::class, $type);
+        self::assertInstanceOf(Revenue::class, $type);
     }
 
     public function testInvalidType(): void


### PR DESCRIPTION
As the methods are static, the calls should be static, too.

And as the methods are not expected to be overwritten in subclasses,
`static::` is not needed, and `self::` will suffice.