### PR TITLE
[CLEANUP] Rename ResponseTest to CsvResponseTest

### DIFF
--- a/tests/Unit/Response/CsvResponseTest.php
+++ b/tests/Unit/Response/CsvResponseTest.php
@@ -1,14 +1,14 @@
 <?php
 declare(strict_types=1);
 
-namespace MarcusJaschen\Collmex\Tests\Unit;
+namespace MarcusJaschen\Collmex\Tests\Unit\Response;
 
 use MarcusJaschen\Collmex\Csv\ParserInterface;
 use MarcusJaschen\Collmex\Response\CsvResponse;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
-class ResponseTest extends TestCase
+class CsvResponseTest extends TestCase
 {
     protected function tearDown(): void
     {


### PR DESCRIPTION
This test is about the `CsvResponse` class and should be named
accordingly.

Also move the test into the `Response` sub-namespace so that the test
namespace structure matches the namespace structure of the tested classes.