### PR TITLE
[CLEANUP] Reduce the visibility of some Response methods

### DIFF
--- a/src/Response/CsvResponse.php
+++ b/src/Response/CsvResponse.php
@@ -80,7 +80,7 @@ class CsvResponse implements ResponseInterface
      *
      * @return void
      */
-    public function parseCsv($responseBody): void
+    private function parseCsv($responseBody): void
     {
         $this->data = $this->convertEncodingFromCollmex(
             $this->parser->parse(
@@ -206,7 +206,7 @@ class CsvResponse implements ResponseInterface
      *
      * @throws \MarcusJaschen\Collmex\Exception\InvalidTypeIdentifierException
      */
-    protected function createTypeRecords(): void
+    private function createTypeRecords(): void
     {
         $typeFactory = new TypeFactory();
 
@@ -222,7 +222,7 @@ class CsvResponse implements ResponseInterface
      *
      * @return string[]
      */
-    protected function convertEncodingFromCollmex(array $data): array
+    private function convertEncodingFromCollmex(array $data): array
     {
         $filter = new Windows1252ToUtf8();
 

--- a/src/Response/ZipResponse.php
+++ b/src/Response/ZipResponse.php
@@ -90,7 +90,7 @@ class ZipResponse implements ResponseInterface
      *
      * @throws InvalidZipFileException
      */
-    protected function extractFiles(): void
+    private function extractFiles(): void
     {
         $tmpFilename = tempnam(sys_get_temp_dir(), 'collmexphp_');
         file_put_contents($tmpFilename, $this->responseBody);


### PR DESCRIPTION
Method visibility should be as narrow as possible to help static
code analysis, and to make refactorings easier.