### PR TITLE
[TASK] Hard-code the CSV delimiter and enclosure

### DIFF
--- a/src/Csv/FormatInterface.php
+++ b/src/Csv/FormatInterface.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace MarcusJaschen\Collmex\Csv;
+
+/**
+ * This interface defines the format we use and expect for CSV files.
+ *
+ * @author Oliver Klee <typo3-coding@oliverklee.de>
+ */
+interface FormatInterface
+{
+    /**
+     * @var string
+     */
+    public const DELIMITER = ';';
+
+    /**
+     * @var string
+     */
+    public const ENCLOSURE = '"';
+}

--- a/src/Csv/SimpleGenerator.php
+++ b/src/Csv/SimpleGenerator.php
@@ -11,31 +11,12 @@ namespace MarcusJaschen\Collmex\Csv;
 class SimpleGenerator implements GeneratorInterface
 {
     /**
-     * @var string
-     */
-    protected $delimiter;
-
-    /**
-     * @var string
-     */
-    protected $enclosure;
-
-    /**
-     * @param string $delimiter
-     * @param string $enclosure
-     */
-    public function __construct(string $delimiter = ';', string $enclosure = '"')
-    {
-        $this->delimiter = $delimiter;
-        $this->enclosure = $enclosure;
-    }
-
-    /**
      * Generates a CSV string from given array data.
      *
      * @param array $data
      *
      * @return string
+     *
      * @throws \RuntimeException
      */
     public function generate(array $data): string
@@ -65,7 +46,7 @@ class SimpleGenerator implements GeneratorInterface
                 }
             );
 
-            fputcsv($fileHandle, $line, $this->delimiter, $this->enclosure);
+            fputcsv($fileHandle, $line, FormatInterface::DELIMITER, FormatInterface::ENCLOSURE);
         }
 
         rewind($fileHandle);

--- a/src/Csv/SimpleParser.php
+++ b/src/Csv/SimpleParser.php
@@ -13,22 +13,12 @@ class SimpleParser implements ParserInterface
     /**
      * @var string
      */
-    protected $delimiter;
+    private const DELIMITER = ';';
 
     /**
      * @var string
      */
-    protected $enclosure;
-
-    /**
-     * @param string $delimiter
-     * @param string $enclosure
-     */
-    public function __construct(string $delimiter = ';', string $enclosure = '"')
-    {
-        $this->delimiter = $delimiter;
-        $this->enclosure = $enclosure;
-    }
+    private const ENCLOSURE = '"';
 
     /**
      * @param string $csv one or multiple lines of CSV data
@@ -43,7 +33,7 @@ class SimpleParser implements ParserInterface
 
         $data = [];
 
-        while ($line = fgetcsv($tmpHandle, 0, $this->delimiter, $this->enclosure)) {
+        while ($line = fgetcsv($tmpHandle, 0, FormatInterface::DELIMITER, FormatInterface::ENCLOSURE)) {
             $data[] = $line;
         }
 

--- a/tests/Unit/Csv/SimpleGeneratorTest.php
+++ b/tests/Unit/Csv/SimpleGeneratorTest.php
@@ -15,7 +15,7 @@ class SimpleGeneratorTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->generator = new SimpleGenerator(';', '"');
+        $this->generator = new SimpleGenerator();
     }
 
     /**

--- a/tests/Unit/Csv/SimpleParserTest.php
+++ b/tests/Unit/Csv/SimpleParserTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace MarcusJaschen\Collmex\Tests\Unit\Csv;
 
+use MarcusJaschen\Collmex\Csv\FormatInterface;
 use MarcusJaschen\Collmex\Csv\SimpleParser;
 use PHPUnit\Framework\TestCase;
 
@@ -46,23 +47,7 @@ class SimpleParserTest extends TestCase
     /**
      * @test
      */
-    public function parseSeparatesColumnsWithGivenSeparator(): void
-    {
-        $separator = ',';
-        $cellContents1 = 'Hello';
-        $cellContents2 = 'world';
-        $csv = $cellContents1 . $separator . $cellContents2;
-        $subject = new SimpleParser($separator, '"');
-
-        $result = $subject->parse($csv);
-
-        self::assertSame([[$cellContents1, $cellContents2]], $result);
-    }
-
-    /**
-     * @test
-     */
-    public function parseByDefaultSeparatesColumnsWithSemicolon(): void
+    public function parseSeparatesColumnsWithSemicolon(): void
     {
         $separator = ';';
         $cellContents1 = 'Hello';
@@ -77,7 +62,7 @@ class SimpleParserTest extends TestCase
     /**
      * @test
      */
-    public function parseByDefaultUsesDoubleQuotesAsEnclosure(): void
+    public function parseUsesDoubleQuotesAsEnclosure(): void
     {
         $cellContents = "Hello\nworld";
         $csv = '"' . $cellContents . '"';
@@ -92,12 +77,11 @@ class SimpleParserTest extends TestCase
      */
     public function doubleEnclosureEscapesIt(): void
     {
-        $enclosure = '!';
+        $enclosure = FormatInterface::ENCLOSURE;
         $cellContents = $enclosure . $enclosure;
         $csv = $enclosure . $cellContents . $enclosure;
-        $subject = new SimpleParser(';', $enclosure);
 
-        $result = $subject->parse($csv);
+        $result = $this->parser->parse($csv);
 
         self::assertSame([[$enclosure]], $result);
     }


### PR DESCRIPTION
As the delimiter and enclosure are not subject to change for Collmex,
we can hardcode them to reduce code complexity.

Closes #166