### PR TITLE
[BUGFIX] Throw an exception if a ZIP cannot be opened

### DIFF
--- a/src/Response/ZipResponse.php
+++ b/src/Response/ZipResponse.php
@@ -100,8 +100,8 @@ class ZipResponse implements ResponseInterface
 
         $zip = new \ZipArchive();
 
-        if (!$zip->open($tmpFilename)) {
-            throw new InvalidZipFileException('Cannot open ZIP archive ' . $tmpFilename);
+        if ($zip->open($tmpFilename) !== true) {
+            throw new InvalidZipFileException('Cannot open ZIP archive: ' . $tmpFilename);
         }
 
         $zip->extractTo($this->extractDirectory);

--- a/tests/Integration/Response/ZipResponseTest.php
+++ b/tests/Integration/Response/ZipResponseTest.php
@@ -91,8 +91,6 @@ class ZipResponseTest extends TestCase
      */
     public function constructorWithInvalidZipResponseBodyThrowsException(): void
     {
-        self::markTestIncomplete('This exception is not thrown yet. This is a bug.');
-
         $this->expectException(InvalidZipFileException::class);
 
         $responseBody = 'The cake is a lie.';


### PR DESCRIPTION
`ZipArchive::open()` returns error codes on failure, not `false`.

Also polish the exception message a bit.