### PR TITLE
change behaviour for invalid Zip responses

### DIFF
--- a/src/Response/Exception/InvalidZipResponseException.php
+++ b/src/Response/Exception/InvalidZipResponseException.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace MarcusJaschen\Collmex\Response\Exception;
+
+/**
+ * This exception is thrown if an invalid Zip response is
+ * detected, i. e. when a Zip Response doesn't contain
+ * its CSV counterpart.
+ */
+class InvalidZipResponseException extends \RuntimeException
+{
+}

--- a/src/Response/Exception/InvalidZipResponseException.php
+++ b/src/Response/Exception/InvalidZipResponseException.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 namespace MarcusJaschen\Collmex\Response\Exception;
 
 /**
- * This exception is thrown if an invalid Zip response is
- * detected, i. e. when a Zip Response doesn't contain
+ * This exception is thrown if an invalid ZIP response is
+ * detected, i.e., when a ZIP Response does not contain
  * its CSV counterpart.
  */
 class InvalidZipResponseException extends \RuntimeException

--- a/src/Response/ZipResponse.php
+++ b/src/Response/ZipResponse.php
@@ -5,6 +5,7 @@ namespace MarcusJaschen\Collmex\Response;
 
 use MarcusJaschen\Collmex\Csv\ParserInterface;
 use MarcusJaschen\Collmex\Response\Exception\InvalidZipFileException;
+use MarcusJaschen\Collmex\Response\Exception\InvalidZipResponseException;
 use Symfony\Component\Finder\Finder;
 
 /**
@@ -68,11 +69,11 @@ class ZipResponse implements ResponseInterface
     /**
      * Returns the CsvResponse instance for the (first) included CSV file.
      *
-     * @return CsvResponse|null
+     * @return CsvResponse
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidZipResponseException
      */
-    public function getCsvResponse(): ?CsvResponse
+    public function getCsvResponse(): CsvResponse
     {
         $iterator = $this->getFilesByType('csv');
 
@@ -82,7 +83,7 @@ class ZipResponse implements ResponseInterface
             return new CsvResponse($this->responseParser, $csv);
         }
 
-        return null;
+        throw new InvalidZipResponseException('Zip Response doesn\'t contain the required CSV segment');
     }
 
     /**

--- a/src/Response/ZipResponse.php
+++ b/src/Response/ZipResponse.php
@@ -83,7 +83,7 @@ class ZipResponse implements ResponseInterface
             return new CsvResponse($this->responseParser, $csv);
         }
 
-        throw new InvalidZipResponseException('Zip Response doesn\'t contain the required CSV segment');
+        throw new InvalidZipResponseException('Zip Response doesn\'t contain the required CSV segment', 1567429445);
     }
 
     /**

--- a/tests/Integration/Response/ZipResponseTest.php
+++ b/tests/Integration/Response/ZipResponseTest.php
@@ -6,6 +6,7 @@ namespace MarcusJaschen\Collmex\Tests\Integration\Response;
 use MarcusJaschen\Collmex\Csv\SimpleParser;
 use MarcusJaschen\Collmex\Response\CsvResponse;
 use MarcusJaschen\Collmex\Response\Exception\InvalidZipFileException;
+use MarcusJaschen\Collmex\Response\Exception\InvalidZipResponseException;
 use MarcusJaschen\Collmex\Response\ResponseInterface;
 use MarcusJaschen\Collmex\Response\ZipResponse;
 use PHPUnit\Framework\TestCase;
@@ -168,8 +169,10 @@ class ZipResponseTest extends TestCase
     /**
      * @test
      */
-    public function getCsvResponseForZipWithoutCsvFilesReturnsNull(): void
+    public function getCsvResponseForZipWithoutCsvFilesThrowsException(): void
     {
+        $this->expectException(InvalidZipResponseException::class);
+
         $fileName = 'test.txt';
         $responseBody = $this->createZipWithFile($fileName, 'There is no spoon.');
         $subject = new ZipResponse($this->parser, $responseBody);


### PR DESCRIPTION
(fixes #124)

If a Zip response doesn't contain the CSV part, an
`InvalidZipResponseException` is thrown as such a response is invalid
regarding to the Collmex documentation[1]. The previous behaviour was
to silently accept such an invalid response and return `null`.

[1] https://www.collmex.de/cgi-bin/cgi.exe?1005,1,help,api_Rechnungen