### PR TITLE
[BUGFIX] Keep development files out of Composer packages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+/.codeclimate.yml export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.php_cs.dist export-ignore
+/.travis.yml export-ignore
+/phpcs.xml.dist export-ignore
+/phpunit.xml export-ignore
+/psalm.xml export-ignore
+/tests/ export-ignore


### PR DESCRIPTION
This should reduce the size of the packages that are installed with the
`--prefer-dist` option (which is the default).