### PR TITLE
[TASK] Remove the deprecated FilterInterface::filter method

### DIFF
--- a/src/Filter/FilterInterface.php
+++ b/src/Filter/FilterInterface.php
@@ -11,13 +11,6 @@ namespace MarcusJaschen\Collmex\Filter;
 interface FilterInterface
 {
     /**
-     * @param string $input
-     *
-     * @return string
-     */
-    public function filter(string $input): string;
-
-    /**
      * @param string $text
      *
      * @return string

--- a/src/Filter/Utf8ToWindows1252.php
+++ b/src/Filter/Utf8ToWindows1252.php
@@ -13,16 +13,6 @@ use ForceUTF8\Encoding;
 class Utf8ToWindows1252 implements FilterInterface
 {
     /**
-     * @param string $input string or array
-     *
-     * @return string
-     */
-    public function filter(string $input): string
-    {
-        return Encoding::toWin1252($input);
-    }
-
-    /**
      * @param string $text
      *
      * @return string

--- a/src/Filter/Windows1252ToUtf8.php
+++ b/src/Filter/Windows1252ToUtf8.php
@@ -13,18 +13,6 @@ use ForceUTF8\Encoding;
 class Windows1252ToUtf8 implements FilterInterface
 {
     /**
-     * @param string $input string or array
-     *
-     * @return string
-     *
-     * @deprecated
-     */
-    public function filter(string $input): string
-    {
-        return Encoding::toUTF8($input);
-    }
-
-    /**
      * @param string $text
      *
      * @return string


### PR DESCRIPTION
This method has been deprecated in the past.