### PR TITLE
[BUGFIX] Fix the tested function in the FilterTests

### DIFF
--- a/tests/Unit/Filter/Utf8ToWindows1252Test.php
+++ b/tests/Unit/Filter/Utf8ToWindows1252Test.php
@@ -30,11 +30,11 @@ class Utf8ToWindows1252Test extends TestCase
     /**
      * @test
      */
-    public function filterKeepsAsciiTextUnchanged(): void
+    public function filterStringKeepsAsciiTextUnchanged(): void
     {
         $text = 'There is no spoon.';
 
-        $result = $this->subject->filter($text);
+        $result = $this->subject->filterString($text);
 
         self::assertSame($text, $result);
     }

--- a/tests/Unit/Filter/Windows1252ToUtf8Test.php
+++ b/tests/Unit/Filter/Windows1252ToUtf8Test.php
@@ -30,11 +30,11 @@ class Windows1252ToUtf8Test extends TestCase
     /**
      * @test
      */
-    public function filterKeepsAsciiTextUnchanged(): void
+    public function filterStringKeepsAsciiTextUnchanged(): void
     {
         $text = 'There is no spoon.';
 
-        $result = $this->subject->filter($text);
+        $result = $this->subject->filterString($text);
 
         self::assertSame($text, $result);
     }


### PR DESCRIPTION
The tests should be for `filterString`, not for the removed
`filter` method.