### PR TITLE
bugfix: csv response in unzipped zip-file not accessible

### DIFF
--- a/src/Response/ZipResponse.php
+++ b/src/Response/ZipResponse.php
@@ -79,7 +79,7 @@ class ZipResponse implements ResponseInterface
         $iterator = $this->getFilesByType('csv');
 
         foreach ($iterator as $file) {
-            $csv = file_get_contents($file);
+            $csv = file_get_contents($file->getPathName());
 
             return new CsvResponse($this->responseParser, $csv);
         }

--- a/tests/Integration/Response/ZipResponseTest.php
+++ b/tests/Integration/Response/ZipResponseTest.php
@@ -188,8 +188,6 @@ class ZipResponseTest extends TestCase
      */
     public function getCsvResponseForZipWithCsvFilesReturnsCsvResponseWithCsvContents(): void
     {
-        self::markTestIncomplete('The tested code has a bug that needs to be fixed first.');
-
         $fileName = 'test.csv';
         $responseBody = $this->createZipWithFile($fileName, 'There is no spoon.');
         $subject = new ZipResponse($this->parser, $responseBody);


### PR DESCRIPTION
When trying to run DeliveryGet with request for bill of delivery I got this error:

```
Fatal error:  Uncaught TypeError: file_get_contents() expects parameter 1 to be a valid path, object given in C:\xampp\htdocs\perola-api\vendor\mjaschen\collmex\src\Response\ZipResponse.php:82
Stack trace:
#0 C:\xampp\htdocs\perola-api\vendor\mjaschen\collmex\src\Response\ZipResponse.php(82): file_get_contents(Object(Symfony\Component\Finder\SplFileInfo))
```

This fix accesses the pathName property to get a valid path for file_get_contents.