### PR TITLE
[TASK] Drop PSR-2 from the code sniffing configuration

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -7,9 +7,6 @@
     <arg name="colors"/>
     <arg name="extensions" value="php"/>
 
-    <!--The complete PSR-2 rule set-->
-    <rule ref="PSR2"/>
-
     <!--The complete PSR-12 rule set-->
     <rule ref="PSR12"/>
 


### PR DESCRIPTION
PSR-12 (which we use) has superseded PSR-2.

(In the code fixer configuration, we are still referring to the
PSR-2 fixer set as long as no PSR-12 fixer set is available.)