### PR TITLE
[BUGFIX] Stop caching vendor/ on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ php:
 
 cache:
   directories:
-  - vendor
   - $HOME/.composer/cache
 
 env:


### PR DESCRIPTION
Caching this directory creates problems between builds with different
PHP versions and highest/lowest dependencies.

Caching the Composer cache directory should suffice to not download
the packages.