### PR TITLE
[TASK] Support all security-supported Symfony versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,8 @@
         "ext-zip": "*",
         "ext-fileinfo": "*",
         "neitanod/forceutf8": "^2.0",
-        "symfony/finder": "^5.0",
-        "symfony/http-foundation": "^5.0.7 || ^5.1"
+        "symfony/finder": "^3.4 || ^4.4 || ^5.1",
+        "symfony/http-foundation": "^3.4 || ^4.4 || ^5.1"
     },
     "require-dev": {
         "laravel/framework": "^7.2",


### PR DESCRIPTION
As this package is a library, it should not limit is compatibility
with different versions of Symfony without need.

Now we support all versions of Symfony that still receive security
updates (as listed on https://symfony.com/releases), not more and
not less.