### PR TITLE
Hotfix: Default param error within customer order and invoice regarding to Collmex conversation

### DIFF
--- a/src/Type/CustomerOrder.php
+++ b/src/Type/CustomerOrder.php
@@ -270,8 +270,8 @@ class CustomerOrder extends AbstractType implements TypeInterface
         'discount_id' => null,
         'discount_final' => null,
         'discount_reason' => null,
-        'confirmation_text' => null,
-        'final_text' => null,
+        'confirmation_text' => '(NULL)',
+        'final_text' => '(NULL)',
         // 40
         'internal_memo' => null,
         'partial_invoices' => null,

--- a/src/Type/Invoice.php
+++ b/src/Type/Invoice.php
@@ -249,8 +249,8 @@ class Invoice extends AbstractType implements TypeInterface
         'discount_id' => null,
         'discount_final' => null,
         'discount_reason' => null,
-        'invoice_text' => null,
-        'final_text' => null,
+        'invoice_text' => '(NULL)',
+        'final_text' => '(NULL)',
         // 40
         'annotation' => null,
         'deleted' => null,


### PR DESCRIPTION
Hi Marcus,

just talked with Collmex about the fact that the default "Schlusstext" Baustein is not automatically set. Regarding to this I've changed the default param value of the regarding field. Tested and works now.

Collmex answer:

In diesem Datensatz ist das Feld für den Schlusstext leer. Entsprechend
ist auch der Schlusstext in der Rechnung leer, d.h. beim Anlegen der
Rechnung in Collmex wird zuerst der Standard-Textbaustein gesetzt, dann
aber mit der übergebenen leeren Zeichenkette überschrieben.

Damit für Zeichenfelder das Feld nicht geändert wird, muss zur Lösung
des Problems der Wert `(NULL) `übergeben werden.

If possible, please do a short hotfix so that I can run a composer update.