### PR TITLE
Added TYPE "CMXEPF" to TYPE_CLASS_MAP in TypeFactory

### DIFF
--- a/src/TypeFactory.php
+++ b/src/TypeFactory.php
@@ -14,6 +14,7 @@ use MarcusJaschen\Collmex\Type\BillOfMaterial;
 use MarcusJaschen\Collmex\Type\Customer;
 use MarcusJaschen\Collmex\Type\CustomerOrder;
 use MarcusJaschen\Collmex\Type\Delivery;
+use MarcusJaschen\Collmex\Type\DifferentShippingAddress;
 use MarcusJaschen\Collmex\Type\Invoice;
 use MarcusJaschen\Collmex\Type\InvoiceOutput;
 use MarcusJaschen\Collmex\Type\InvoicePayment;
@@ -80,6 +81,7 @@ class TypeFactory
         'STOCK_CHANGE' => StockChange::class,
         'PRODUCTION_ORDER' => ProductionOrder::class,
         'VOUCHER' => Voucher::class,
+        'CMXEPF' => DifferentShippingAddress::class,
     ];
 
     /**


### PR DESCRIPTION
The Type CMXEPF / DifferentShippingAddress is created as a type but not present in the TypeFactory. 

By adding this it's possible to use CUSTOMER_RECEIVING_ADDRESS_GET