### PR TITLE
Release/3.x

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,11 +16,9 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.3"
-          - "7.4"
-          - "8.0"
           - "8.1"
           - "8.2"
+          - "8.3"
         composer-dependencies:
           - ""
           - "--prefer-lowest"

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /composer.lock
 /docs/collmex.html
 /vendor/
+.phpunit.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/)
 principles.
 
+## [3.0.0]
+
+**Warning: Backwards-compatibility-breaking changes**
+
+### Added
+
+- support for PHP 8.3
+
+### Removed
+
+- support for PHP 7
+- support for PHP 8.0
+- support for old Symfony components (4.x, 5.x)
+
+### Changed
+
+- `Request::send()` and `MultiRequest::send()` are type-hinted to return
+  a `ResponseInterface` instead of a concrete implementation (i.e.
+  `CsvResponse` or `ZipResonse`).  
+
 ## [2.12.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -23,14 +23,29 @@ There is (or least should be…) a *Type* class for every Collmex record type
 
 ## Compatibility
 
-The Collmex PHP SDK requires PHP >= 7.3. If you're still using an ancient PHP
-version, you can install older versions of the Collmex PHP SDK:
+The Collmex PHP SDK requires PHP >= 8.1. It's possible to install an older
+version of the Collmex PHP SDK, if you're still using a no longer supported
+PHP version:
 
-- for PHP 7.2 compatibility: use the 1.x tags (`composer require mjaschen/collmex:^1.0`); this version will receive security updates until version 3.0 is released.
+- for PHP 7.3, 7.4 and 8.0 compatibility: use the 2.x tags (`composer require mjaschen/collmex:^2.0`); this version will receive security updates until version 4.0 is released.
+- for PHP 7.2 compatibility: use the 1.x tags (`composer require mjaschen/collmex:^1.0`); this version won't receive any updates.
 - for PHP 7.0 compatibility: use the 0.12.x tags (`composer require mjaschen/collmex:^0.12`); this version won't receive any updates.
 - for PHP 5.6 compatibility: use the 0.11.x tags (`composer require mjaschen/collmex:^0.11`); this version won't receive any updates.
 
 New features will only go into the main branch and won't be backported.
+
+| PHP Version | Collmex PHP SDK Version | Support Status   |
+|-------------|-------------------------|------------------|
+| 8.3         | 3.x                     | ✅ active         |
+| 8.2         | 3.x                     | ✅ active         |
+| 8.1         | 3.x                     | ✅ active         |
+| 8.0         | 2.x                     | ⚠️ security only |
+| 7.4         | 2.x                     | ⚠️ security only |
+| 7.3         | 2.x                     | ⚠️ security only |
+| 7.2         | 1.x                     | ❌ end of life    |
+| 7.1         | 1.x                     | ❌ end of life    |
+| 7.0         | 1.x                     | ❌ end of life    |
+| 5.6         | 0.11.x                  | ❌ end of life    |
 
 ## Installation
 
@@ -59,15 +74,30 @@ return [
 
 ## Upgrading
 
+### Version 2.x to 3.x
+
+1. Read the [change log](https://github.com/mjaschen/collmex/blob/main/CHANGELOG.md).
+   You will see the list of everything changed between versions 1 and 2.
+2. Ensure your codebase is compatible with all requirements in `composer.json`.
+3. Update your `composer.json` to require version 3.x of the Collmex PHP SDK:
+
+  ```json
+  {
+    "require": {
+      "mjaschen/collmex": "^3.0"
+    }
+  }
+  ```
+
 ### Version 1.x to 2.x
 
 1. Read the [change log](https://github.com/mjaschen/collmex/blob/main/CHANGELOG.md).
-You will see the list of everything changed between versions 1 and 2.
-1. Ensure your codebase is compatible with all requirements in `composer.json`.
-1. Rename attributes which are used in your codebase. Some attributes
-in the type classes have been renamed. If you use these attributes, you have
-to adjust your code as well. A simple search-and-replace is sufficient for
-this. Below you will find the complete list of renamed attributes:
+   You will see the list of everything changed between versions 1 and 2.
+2. Ensure your codebase is compatible with all requirements in `composer.json`.
+3. Rename attributes which are used in your codebase. Some attributes
+   in the type classes have been renamed. If you use these attributes, you have
+   to adjust your code as well. A simple search-and-replace is sufficient for
+   this. Below you will find the complete list of renamed attributes:
 
 | Class                      | Old Name                      | New Name                     |
 |----------------------------|-------------------------------|------------------------------|

--- a/composer.json
+++ b/composer.json
@@ -25,26 +25,27 @@
         "source": "https://github.com/mjaschen/collmex"
     },
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^8.1",
         "ext-curl": "*",
         "ext-fileinfo": "*",
         "ext-json": "*",
         "ext-zip": "*",
-        "symfony/finder": "^4.4 || ^5.4 || ^6.0",
-        "symfony/http-foundation": "^4.4 || ^5.4 || ^6.0",
-        "symfony/mime": "^4.4 || ^5.4 || ^6.0",
-        "symfony/string": "^5.4 || ^6.0"
+        "symfony/finder": "^6.0",
+        "symfony/http-foundation": "^6.0",
+        "symfony/mime": "^6.0",
+        "symfony/string": "^6.0"
     },
     "require-dev": {
         "dereuromark/composer-prefer-lowest": "^0.1.10",
-        "ergebnis/composer-normalize": "^2.20.0",
+        "ergebnis/composer-normalize": "^2.0",
         "friendsofphp/php-cs-fixer": "^3.0",
         "laravel/framework": ">=7.2",
-        "mockery/mockery": "^1.5",
-        "moneyphp/money": "^3.3.2 || ^4.0",
-        "phpunit/phpunit": "^9.5.5",
+        "mockery/mockery": "^1.6",
+        "moneyphp/money": "^4.0",
+        "phpunit/phpunit": "^10.0",
+        "rector/rector": "^0.18.6",
         "squizlabs/php_codesniffer": "^3.7",
-        "vimeo/psalm": "^4.26"
+        "vimeo/psalm": "^5.0"
     },
     "prefer-stable": true,
     "autoload": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,17 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
->
-    <testsuites>
-        <testsuite name="Package Test Suite">
-            <directory suffix=".php">./tests/</directory>
-        </testsuite>
-    </testsuites>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <testsuites>
+    <testsuite name="Package Test Suite">
+      <directory suffix=".php">./tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/psalm.xml
+++ b/psalm.xml
@@ -2,6 +2,8 @@
 <psalm
     errorLevel="3"
     resolveFromConfigFile="true"
+    findUnusedBaselineEntry="true"
+    findUnusedCode="false"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"

--- a/src/AbstractRequest.php
+++ b/src/AbstractRequest.php
@@ -7,31 +7,12 @@ namespace MarcusJaschen\Collmex;
 use MarcusJaschen\Collmex\Client\ClientInterface;
 use MarcusJaschen\Collmex\Csv\Parser;
 
-/**
- * Abstract Collmex Request Class.
- *
- * @author Marcus Jaschen <mail@marcusjaschen.de>
- * @author Timo Paul <mail@timopaul.biz>
- */
 abstract class AbstractRequest implements RequestInterface
 {
-    /**
-     * @var ClientInterface
-     */
-    protected $client;
+    protected Parser $responseParser;
 
-    /**
-     * @var Parser
-     */
-    protected $responseParser;
-
-    /**
-     * @param ClientInterface $client
-     */
-    public function __construct(ClientInterface $client)
+    public function __construct(protected ClientInterface $client)
     {
-        $this->client = $client;
-
         $this->responseParser = new Parser();
     }
 }

--- a/src/Client/AbstractClient.php
+++ b/src/Client/AbstractClient.php
@@ -7,56 +7,17 @@ namespace MarcusJaschen\Collmex\Client;
 use MarcusJaschen\Collmex\Csv\Generator;
 use MarcusJaschen\Collmex\Filter\Utf8ToWindows1252;
 
-/**
- * Abstract Client Class.
- *
- * @author   Marcus Jaschen <mail@marcusjaschen.de>
- */
 abstract class AbstractClient
 {
-    /**
-     * The Collmex API endpoint URL template.
-     *
-     * @var string
-     */
-    public const EXCHANGE_URL = 'https://www.collmex.de/c.cmx?%s,0,data_exchange';
+    final public const EXCHANGE_URL = 'https://www.collmex.de/c.cmx?%s,0,data_exchange';
 
-    /**
-     * The Collmex API endpoint URL.
-     *
-     * @var string
-     */
-    protected $exchangeUrl;
+    protected string $exchangeUrl;
 
-    /**
-     * @var string
-     */
-    protected $user;
-
-    /**
-     * @var string
-     */
-    protected $password;
-
-    /**
-     * @param string $user
-     * @param string $password
-     * @param string $customer
-     */
-    public function __construct(string $user, string $password, string $customer)
+    public function __construct(protected string $user, protected string $password, string $customer)
     {
-        $this->user = $user;
-        $this->password = $password;
         $this->exchangeUrl = sprintf(static::EXCHANGE_URL, $customer);
     }
 
-    /**
-     * Converts the text to Windows Codepage 1252 encoding.
-     *
-     * @param string $text
-     *
-     * @return string
-     */
     protected function convertEncodingForCollmex(string $text): string
     {
         $filter = new Utf8ToWindows1252();
@@ -67,8 +28,6 @@ abstract class AbstractClient
     /**
      * Creates the first line of the request body - it contains the
      * authentication credentials.
-     *
-     * @return string
      */
     protected function getLoginLine(): string
     {

--- a/src/Client/ClientInterface.php
+++ b/src/Client/ClientInterface.php
@@ -4,19 +4,10 @@ declare(strict_types=1);
 
 namespace MarcusJaschen\Collmex\Client;
 
-/**
- * API Client Interface.
- *
- * @author   Marcus Jaschen <mail@marcusjaschen.de>
- */
 interface ClientInterface
 {
     /**
      * Executes the actual HTTP request and creates the Response object.
-     *
-     * @param $body
-     *
-     * @return string The response body
      *
      * @throws Exception\RequestFailedException
      */

--- a/src/Client/Curl.php
+++ b/src/Client/Curl.php
@@ -4,26 +4,15 @@ declare(strict_types=1);
 
 namespace MarcusJaschen\Collmex\Client;
 
+use CurlHandle;
 use MarcusJaschen\Collmex\Client\Exception\RequestFailedException;
 
-/**
- * curl Client Class.
- *
- * @author   Marcus Jaschen <mail@marcusjaschen.de>
- */
 class Curl extends AbstractClient implements ClientInterface
 {
-    /**
-     * @var resource
-     */
-    protected $curl;
+    protected CurlHandle $curl;
 
     /**
      * Executes the actual HTTP request and creates the Response object.
-     *
-     * @param $body
-     *
-     * @return string The response body
      *
      * @throws RequestFailedException
      */
@@ -52,25 +41,16 @@ class Curl extends AbstractClient implements ClientInterface
         return (string)$response;
     }
 
-    /**
-     * Creates curl ressource.
-     *
-     * @return void
-     */
     protected function initCurl(): void
     {
         $this->curl = curl_init($this->exchangeUrl);
+
         curl_setopt($this->curl, CURLOPT_POST, true);
         curl_setopt($this->curl, CURLOPT_HTTPHEADER, ['Content-Type: text/csv']);
         curl_setopt($this->curl, CURLOPT_SSL_VERIFYPEER, true);
         curl_setopt($this->curl, CURLOPT_RETURNTRANSFER, true);
     }
 
-    /**
-     * Closes curl ressource.
-     *
-     * @return void
-     */
     protected function destroyCurl(): void
     {
         if (!empty($this->curl)) {
@@ -80,10 +60,6 @@ class Curl extends AbstractClient implements ClientInterface
 
     /**
      * Prepend the login credentials to the request body.
-     *
-     * @param string $body
-     *
-     * @return string
      */
     protected function buildRequestBody(string $body): string
     {

--- a/src/CollmexField/Date.php
+++ b/src/CollmexField/Date.php
@@ -4,12 +4,16 @@ declare(strict_types=1);
 
 namespace MarcusJaschen\Collmex\CollmexField;
 
+use DateTime;
+use DateTimeZone;
+use InvalidArgumentException;
+
 class Date
 {
     /**
      * Converts DateTime instance to Collmex date format.
      */
-    public static function fromDateTime(\DateTime $dateTime): string
+    public static function fromDateTime(DateTime $dateTime): string
     {
         return $dateTime->format('Ymd');
     }
@@ -19,35 +23,51 @@ class Date
      *
      * @see https://www.collmex.de/c.cmx?1005,1,help,daten_importieren_datentypen_felder
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
-    public static function toDateTime(string $value, ?\DateTimeZone $timeZone = null): \DateTime
+    public static function toDateTime(string $value, ?DateTimeZone $timeZone = null): DateTime
     {
         if ($timeZone === null) {
             // Europe/Berlin is probably a sane choice here as Collmex targets german customers ...
-            $timeZone = new \DateTimeZone('Europe/Berlin');
+            $timeZone = new DateTimeZone('Europe/Berlin');
         }
 
         // ISO format YYYYMMDD
         if (preg_match('/^(\d{8})$/', $value) === 1) {
-            return new \DateTime(
-                substr($value, 0, 4) . '-'
-                . substr($value, 4, 2) . '-'
-                . substr($value, 6),
-                $timeZone
-            );
+            try {
+                return new DateTime(
+                    substr($value, 0, 4) . '-'
+                    . substr($value, 4, 2) . '-'
+                    . substr($value, 6),
+                    $timeZone
+                );
+            } catch (\Exception $exception) {
+                throw new InvalidArgumentException(
+                    'Cannot create DateTime object - invalid date string: ' . $value,
+                    3_667_838_412,
+                    $exception
+                );
+            }
         }
 
         // German format DD.MM.YYYY
         if (preg_match('/^(\d{2}\.\d{2}\.\d{4})$/', $value) === 1) {
-            return new \DateTime(
-                substr($value, 6) . '-'
-                . substr($value, 3, 2) . '-'
-                . substr($value, 0, 2),
-                $timeZone
-            );
+            try {
+                return new DateTime(
+                    substr($value, 6) . '-'
+                    . substr($value, 3, 2) . '-'
+                    . substr($value, 0, 2),
+                    $timeZone
+                );
+            } catch (\Exception $exception) {
+                throw new InvalidArgumentException(
+                    'Cannot create DateTime object - invalid date string: ' . $value,
+                    2_033_421_948,
+                    $exception
+                );
+            }
         }
 
-        throw new \InvalidArgumentException('Invalid date value: ' . $value, 3746303620);
+        throw new InvalidArgumentException('Invalid date value: ' . $value, 3_746_303_620);
     }
 }

--- a/src/Csv/FormatInterface.php
+++ b/src/Csv/FormatInterface.php
@@ -6,8 +6,6 @@ namespace MarcusJaschen\Collmex\Csv;
 
 /**
  * This interface defines the format we use and expect for CSV files.
- *
- * @author Oliver Klee <typo3-coding@oliverklee.de>
  */
 interface FormatInterface
 {

--- a/src/Csv/Generator.php
+++ b/src/Csv/Generator.php
@@ -6,11 +6,6 @@ namespace MarcusJaschen\Collmex\Csv;
 
 use RuntimeException;
 
-/**
- * CSV Generator Class.
- *
- * @author   Marcus Jaschen <mail@marcusjaschen.de>
- */
 class Generator
 {
     private const PLACEHOLDER_FPUTCSV_BUG = 'MJASCHEN_COLLMEX_WORKAROUND_PHP_BUG_43225';
@@ -67,7 +62,7 @@ class Generator
         $fileHandle = fopen('php://temp', 'wb');
 
         if (!$fileHandle) {
-            throw new RuntimeException('Cannot open temp file handle (php://temp)', 5529946737);
+            throw new RuntimeException('Cannot open temp file handle (php://temp)', 5_529_946_737);
         }
 
         $csvCreator($fileHandle);

--- a/src/Csv/Parser.php
+++ b/src/Csv/Parser.php
@@ -4,11 +4,6 @@ declare(strict_types=1);
 
 namespace MarcusJaschen\Collmex\Csv;
 
-/**
- * CSV Parser Implementation using PHP's built-in CSV handling capabilities.
- *
- * @author   Marcus Jaschen <mail@marcusjaschen.de>
- */
 class Parser
 {
     private const PLACEHOLDER_FGETCSV_BUG = 'MJASCHEN_COLLMEX_WORKAROUND_PHP_FGETCSV_BUG';
@@ -26,10 +21,6 @@ class Parser
      * @see Generator
      * @see \MarcusJaschen\Collmex\Tests\Unit\Csv\ParserTest::parseBackslashFollowedByDoubleQuote()
      * @see https://github.com/mjaschen/collmex/issues/238
-     *
-     * @param string $csv one or multiple lines of CSV data
-     *
-     * @return array
      */
     public function parse(string $csv): array
     {

--- a/src/Exception/InvalidResponseException.php
+++ b/src/Exception/InvalidResponseException.php
@@ -1,9 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-namespace MarcusJaschen\Collmex\Exception;
-
-class InvalidResponseException extends \Exception
-{
-}

--- a/src/Filter/AbstractFilter.php
+++ b/src/Filter/AbstractFilter.php
@@ -6,9 +6,6 @@ namespace MarcusJaschen\Collmex\Filter;
 
 abstract class AbstractFilter implements FilterInterface
 {
-    /**
-     * @inheritdoc
-     */
     public function filterArray(array $data): array
     {
         foreach ($data as $key => $value) {

--- a/src/Filter/FilterInterface.php
+++ b/src/Filter/FilterInterface.php
@@ -4,11 +4,6 @@ declare(strict_types=1);
 
 namespace MarcusJaschen\Collmex\Filter;
 
-/**
- * Filter Interface.
- *
- * @author   Marcus Jaschen <mail@marcusjaschen.de>
- */
 interface FilterInterface
 {
     public function filterString(string $text): string;

--- a/src/Filter/Utf8ToWindows1252.php
+++ b/src/Filter/Utf8ToWindows1252.php
@@ -7,11 +7,6 @@ namespace MarcusJaschen\Collmex\Filter;
 use InvalidArgumentException;
 use Symfony\Component\String\UnicodeString;
 
-/**
- * Filter to convert UTF-8 to Windows 1252 encoding.
- *
- * @author   Marcus Jaschen <mail@marcusjaschen.de>
- */
 class Utf8ToWindows1252 extends AbstractFilter
 {
     /**
@@ -22,7 +17,7 @@ class Utf8ToWindows1252 extends AbstractFilter
         $result = mb_convert_encoding((string)(new UnicodeString($text)), 'Windows-1252', 'UTF-8');
 
         if ($result === false) {
-            throw new InvalidArgumentException('Cannot convert string to Windows-1252', 2132076004);
+            throw new InvalidArgumentException('Cannot convert string to Windows-1252', 2_132_076_004);
         }
 
         return $result;

--- a/src/Filter/Windows1252ToUtf8.php
+++ b/src/Filter/Windows1252ToUtf8.php
@@ -4,14 +4,8 @@ declare(strict_types=1);
 
 namespace MarcusJaschen\Collmex\Filter;
 
-use ForceUTF8\Encoding;
 use InvalidArgumentException;
 
-/**
- * Filter to convert Windows 1252 to UTF-8 encoding.
- *
- * @author   Marcus Jaschen <mail@marcusjaschen.de>
- */
 class Windows1252ToUtf8 extends AbstractFilter
 {
     /**
@@ -22,7 +16,7 @@ class Windows1252ToUtf8 extends AbstractFilter
         $result = mb_convert_encoding($text, 'UTF-8', 'Windows-1252');
 
         if ($result === false) {
-            throw new InvalidArgumentException('Cannot convert string to UTF-8', 8609163127);
+            throw new InvalidArgumentException('Cannot convert string to UTF-8', 8_609_163_127);
         }
 
         return $result;

--- a/src/MultiRequest.php
+++ b/src/MultiRequest.php
@@ -7,25 +7,14 @@ namespace MarcusJaschen\Collmex;
 use MarcusJaschen\Collmex\Client\Exception\RequestFailedException;
 use MarcusJaschen\Collmex\Exception\InvalidResponseMimeTypeException;
 use MarcusJaschen\Collmex\Exception\RequestErrorException;
-use MarcusJaschen\Collmex\Response\CsvResponse;
 use MarcusJaschen\Collmex\Response\ResponseFactory;
-use MarcusJaschen\Collmex\Response\ZipResponse;
+use MarcusJaschen\Collmex\Response\ResponseInterface;
 use MarcusJaschen\Collmex\Type\TypeInterface;
 
 class MultiRequest extends AbstractRequest
 {
-    /**
-     * @var array
-     */
-    private $types = [];
+    private array $types = [];
 
-    /**
-     * Adds a new type for the request.
-     *
-     * @param TypeInterface $type
-     *
-     * @return  MultiRequest
-     */
     public function add(TypeInterface $type): self
     {
         $this->types[] = $type;
@@ -37,8 +26,6 @@ class MultiRequest extends AbstractRequest
      * Adds multiple types for the request.
      *
      * @param TypeInterface[] $types
-     *
-     * @return MultiRequest
      */
     public function push(array $types): self
     {
@@ -50,38 +37,29 @@ class MultiRequest extends AbstractRequest
     }
 
     /**
-     * merges all request.
-     *
-     * @return string
      * @throws RequestErrorException
      */
     private function buildRequestBody(): string
     {
-        if (0 === count($this->types)) {
-            throw new RequestErrorException('Request data empty', 7294275601);
+        if (count($this->types) === 0) {
+            throw new RequestErrorException('Request data empty', 7_294_275_601);
         }
 
         return implode(
             PHP_EOL,
             array_map(
-                static function ($type): string {
-                    return $type->getCsv();
-                },
+                static fn($type): string => $type->getCsv(),
                 $this->types
             )
         );
     }
 
     /**
-     * Sends multiple API request and returns the response object.
-     *
-     * @return ZipResponse|CsvResponse
-     *
      * @throws InvalidResponseMimeTypeException
      * @throws RequestFailedException
      * @throws RequestErrorException
      */
-    public function send()
+    public function send(): ResponseInterface
     {
         $response = $this->client->request($this->buildRequestBody());
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -6,28 +6,18 @@ namespace MarcusJaschen\Collmex;
 
 use MarcusJaschen\Collmex\Client\Exception\RequestFailedException;
 use MarcusJaschen\Collmex\Exception\InvalidResponseMimeTypeException;
-use MarcusJaschen\Collmex\Response\CsvResponse;
 use MarcusJaschen\Collmex\Response\ResponseFactory;
-use MarcusJaschen\Collmex\Response\ZipResponse;
+use MarcusJaschen\Collmex\Response\ResponseInterface;
 
-/**
- * Collmex API Request.
- *
- * @author Marcus Jaschen <mail@marcusjaschen.de>
- */
 class Request extends AbstractRequest
 {
     /**
      * Sends an API request and returns the response object.
      *
-     * @param string $body The request body
-     *
-     * @return ZipResponse|CsvResponse
-     *
      * @throws InvalidResponseMimeTypeException
      * @throws RequestFailedException
      */
-    public function send(string $body)
+    public function send(string $body): ResponseInterface
     {
         $response = $this->client->request($body);
 

--- a/src/RequestInterface.php
+++ b/src/RequestInterface.php
@@ -4,11 +4,6 @@ declare(strict_types=1);
 
 namespace MarcusJaschen\Collmex;
 
-/**
- * Collmex Request Interface.
- *
- * @author   Timo Paul <mail@timopaul.biz>
- */
 interface RequestInterface
 {
 }

--- a/src/Response/CsvResponse.php
+++ b/src/Response/CsvResponse.php
@@ -15,7 +15,7 @@ class CsvResponse implements ResponseInterface
     /**
      * Array containing lines of raw response data.
      *
-     * @var string[]
+     * @var array<array-key, array<array-key, string>|string>
      */
     protected array $data;
 
@@ -101,7 +101,7 @@ class CsvResponse implements ResponseInterface
             return null;
         }
 
-        if (null === $this->records) {
+        if ($this->records === null) {
             $this->createTypeRecords();
         }
 
@@ -147,7 +147,7 @@ class CsvResponse implements ResponseInterface
      *
      * @param array<array-key, array<array-key, string>|string> $data
      *
-     * @return array<array-key, array<array-key, string>|string>
+     * @return string[]
      */
     private function convertEncodingFromCollmex(array $data): array
     {

--- a/src/Response/CsvResponse.php
+++ b/src/Response/CsvResponse.php
@@ -13,76 +13,35 @@ use MarcusJaschen\Collmex\TypeFactory;
 class CsvResponse implements ResponseInterface
 {
     /**
-     * @var Parser
-     */
-    protected $parser;
-
-    /**
-     * The unparsed response CSV string.
+     * Array containing lines of raw response data.
      *
-     * @var string
+     * @var string[]
      */
-    protected $responseRaw;
-
-    /**
-     * @var array of raw response data
-     */
-    protected $data;
+    protected array $data;
 
     /**
      * @var AbstractType[]|null
      */
-    protected $records;
+    protected array|null $records = null;
 
-    /**
-     * Collmex error-code.
-     *
-     * @var string|null
-     */
-    protected $errorCode;
+    protected string|null $errorCode = null;
 
-    /**
-     * @var string|null
-     */
-    protected $errorMessage;
+    protected string|null $errorMessage = null;
 
     /**
      * Line of request CSV where the error occurred.
-     *
-     * @var int
      */
-    protected $errorLine;
+    protected int|null $errorLine = null;
 
-    /**
-     * @param Parser $parser
-     * @param string $responseBody
-     */
-    public function __construct(Parser $parser, string $responseBody)
-    {
-        $this->parser = $parser;
-        $this->responseRaw = $responseBody;
-
-        $this->parseCsv($responseBody);
-    }
-
-    /**
-     * @param string $responseBody
-     *
-     * @return void
-     */
-    private function parseCsv($responseBody): void
+    public function __construct(protected Parser $parser, protected string $responseRaw)
     {
         $this->data = $this->convertEncodingFromCollmex(
-            $this->parser->parse(
-                $responseBody
-            )
+            $this->parser->parse($responseRaw)
         );
     }
 
     /**
      * Checks if the API request returned an error.
-     *
-     * @return bool
      */
     public function isError(): bool
     {
@@ -102,34 +61,23 @@ class CsvResponse implements ResponseInterface
         return false;
     }
 
-    /**
-     * @return string|null
-     */
-    public function getErrorMessage(): ?string
+    public function getErrorMessage(): string|null
     {
         return $this->errorMessage;
     }
 
-    /**
-     * @return string|null
-     */
-    public function getErrorCode(): ?string
+    public function getErrorCode(): string|null
     {
         return $this->errorCode;
     }
 
-    /**
-     * @return int
-     */
-    public function getErrorLine(): int
+    public function getErrorLine(): int|null
     {
         return $this->errorLine;
     }
 
     /**
      * Returns the unparsed contents of the Collmex response (CSV string).
-     *
-     * @return string
      */
     public function getResponseRaw(): string
     {
@@ -143,7 +91,7 @@ class CsvResponse implements ResponseInterface
      *
      * @throws InvalidTypeIdentifierException
      */
-    public function getRecords(): ?array
+    public function getRecords(): array|null
     {
         if ($this->isError()) {
             return null;
@@ -168,7 +116,7 @@ class CsvResponse implements ResponseInterface
      *
      * @throws InvalidTypeIdentifierException
      */
-    public function getFirstRecord(): ?AbstractType
+    public function getFirstRecord(): AbstractType|null
     {
         $records = $this->getRecords();
 
@@ -182,8 +130,6 @@ class CsvResponse implements ResponseInterface
     /**
      * Populates the $records attribute with Type objects, created
      * from $data attribute.
-     *
-     * @return void
      *
      * @throws InvalidTypeIdentifierException
      */

--- a/src/Response/ResponseFactory.php
+++ b/src/Response/ResponseFactory.php
@@ -11,30 +11,12 @@ use Symfony\Component\HttpFoundation\File\File;
 
 class ResponseFactory
 {
-    /**
-     * @var string
-     */
-    protected $responseBody;
-
-    /**
-     * @var Parser
-     */
-    protected $responseParser;
-
-    /**
-     * @param string $responseBody
-     * @param Parser $responseParser
-     */
-    public function __construct(string $responseBody, Parser $responseParser)
+    public function __construct(protected string $responseBody, protected Parser $responseParser)
     {
-        $this->responseBody = $responseBody;
-        $this->responseParser = $responseParser;
     }
 
     /**
      * Returns the class name which handles the response ('CsvResponse' or 'ZipResponse').
-     *
-     * @return ZipResponse|CsvResponse
      *
      * @throws InvalidResponseMimeTypeException
      */
@@ -56,11 +38,9 @@ class ResponseFactory
     /**
      * Determines MIME type of response body.
      *
-     * @return string|null
-     *
      * @throws FileNotFoundException
      */
-    protected function getResponseMimeType(): ?string
+    protected function getResponseMimeType(): string|null
     {
         $tmpFilename = tempnam(sys_get_temp_dir(), 'collmexphp_');
         file_put_contents($tmpFilename, $this->responseBody);

--- a/src/Response/ResponseInterface.php
+++ b/src/Response/ResponseInterface.php
@@ -4,11 +4,6 @@ declare(strict_types=1);
 
 namespace MarcusJaschen\Collmex\Response;
 
-/**
- * Interface for Response class.
- *
- * @author  Marcus Jaschen <mail@marcusjaschen.de>
- */
 interface ResponseInterface
 {
 }

--- a/src/Response/ZipResponse.php
+++ b/src/Response/ZipResponse.php
@@ -9,48 +9,21 @@ use MarcusJaschen\Collmex\Response\Exception\InvalidZipFileException;
 use MarcusJaschen\Collmex\Response\Exception\InvalidZipResponseException;
 use Symfony\Component\Finder\Finder;
 
-/**
- * Collmex ZIP Response Class.
- *
- * @author   Marcus Jaschen <mail@marcusjaschen.de>
- */
 class ZipResponse implements ResponseInterface
 {
-    /**
-     * @var string
-     */
-    protected $responseBody;
+    protected string $extractDirectory;
 
     /**
-     * @var Parser
-     */
-    protected $responseParser;
-
-    /**
-     * @var string
-     */
-    protected $extractDirectory;
-
-    /**
-     * @param Parser $responseParser
-     * @param string $responseBody
      *
      * @throws InvalidZipFileException
      */
-    public function __construct(Parser $responseParser, string $responseBody)
+    public function __construct(protected Parser $responseParser, protected string $responseBody)
     {
-        $this->responseBody = $responseBody;
-        $this->responseParser = $responseParser;
-
         $this->extractFiles();
     }
 
     /**
      * Returns an iterator of files matching the given file extension filter.
-     *
-     * @param string $type
-     *
-     * @return Finder
      *
      * @throws \InvalidArgumentException
      */
@@ -58,19 +31,15 @@ class ZipResponse implements ResponseInterface
     {
         $finder = new Finder();
 
-        $iterator = $finder
+        return $finder
             ->files()
             ->name('*.' . $type)
             ->depth(0)
             ->in($this->extractDirectory);
-
-        return $iterator;
     }
 
     /**
      * Returns the CsvResponse instance for the (first) included CSV file.
-     *
-     * @return CsvResponse
      *
      * @throws InvalidZipResponseException
      */
@@ -84,12 +53,10 @@ class ZipResponse implements ResponseInterface
             return new CsvResponse($this->responseParser, $csv);
         }
 
-        throw new InvalidZipResponseException('Zip Response doesn\'t contain the required CSV segment', 1567429445);
+        throw new InvalidZipResponseException('Zip Response doesn\'t contain the required CSV segment', 1_567_429_445);
     }
 
     /**
-     * @return void
-     *
      * @throws InvalidZipFileException
      */
     private function extractFiles(): void
@@ -102,7 +69,7 @@ class ZipResponse implements ResponseInterface
 
         $this->ensureExtractDirectoryExists();
 
-        if ('' === $this->responseBody) {
+        if ($this->responseBody === '') {
             return;
         }
 
@@ -122,7 +89,10 @@ class ZipResponse implements ResponseInterface
     private function ensureExtractDirectoryExists(): void
     {
         if (!mkdir($this->extractDirectory) && !is_dir($this->extractDirectory)) {
-            throw new \RuntimeException(sprintf('Directory "%s" was not created', $this->extractDirectory), 1631246675);
+            throw new \RuntimeException(
+                sprintf('Directory "%s" was not created', $this->extractDirectory),
+                1_631_246_675
+            );
         }
     }
 }

--- a/src/Type/AbstractType.php
+++ b/src/Type/AbstractType.php
@@ -94,7 +94,7 @@ abstract class AbstractType implements JsonSerializable
      */
     public function toJson(): string
     {
-        return json_encode($this->data);
+        return json_encode($this->data, JSON_THROW_ON_ERROR);
     }
 
     /**
@@ -121,7 +121,7 @@ abstract class AbstractType implements JsonSerializable
         }
 
         throw new InvalidFieldNameException(
-            'Cannot read field value; field "' . $name . '" does not exist in class ' . get_class($this)
+            'Cannot read field value; field "' . $name . '" does not exist in class ' . static::class
         );
     }
 
@@ -133,7 +133,7 @@ abstract class AbstractType implements JsonSerializable
      *
      * @throws InvalidFieldNameException
      */
-    public function __set(string $name, $value): void
+    public function __set(string $name, mixed $value): void
     {
         if ($name === 'type_identifier') {
             throw new InvalidFieldNameException('Cannot overwrite type identifier');
@@ -146,7 +146,7 @@ abstract class AbstractType implements JsonSerializable
         }
 
         throw new InvalidFieldNameException(
-            'Cannot set field value; field "' . $name . '" does not exist in class ' . get_class($this)
+            'Cannot set field value; field "' . $name . '" does not exist in class ' . static::class
         );
     }
 
@@ -193,10 +193,8 @@ abstract class AbstractType implements JsonSerializable
      * Checks if all provided field names are valid: each given field name
      * must exist in $this->template.
      *
-     * @param array $data
      *
      * @return void
-     *
      * @throws InvalidFieldNameException
      */
     private function assertValidFieldNames(array $data): void

--- a/src/Type/Address.php
+++ b/src/Type/Address.php
@@ -53,47 +53,47 @@ class Address extends AbstractType implements TypeInterface
     /**
      * @var int
      */
-    public const ADDRESS_TYPE_CUSTOMER_SUPPLIER_MEMBER = 0;
+    final public const ADDRESS_TYPE_CUSTOMER_SUPPLIER_MEMBER = 0;
 
     /**
      * @var int
      */
-    public const ADDRESS_TYPE_ADDRESS_MANAGEMENT = 3;
+    final public const ADDRESS_TYPE_ADDRESS_MANAGEMENT = 3;
 
     /**
      * @var int
      */
-    public const ADDRESS_TYPE_CONTACT = 4;
+    final public const ADDRESS_TYPE_CONTACT = 4;
 
     /**
      * @var int
      */
-    public const INACTIVE_ACTIVE = 0;
+    final public const INACTIVE_ACTIVE = 0;
 
     /**
      * @var int
      */
-    public const INACTIVE_INACTIVE = 1;
+    final public const INACTIVE_INACTIVE = 1;
 
     /**
      * @var int
      */
-    public const INACTIVE_DELETE = 2;
+    final public const INACTIVE_DELETE = 2;
 
     /**
      * @var int
      */
-    public const INACTIVE_DELETE_UNUSED = 3;
+    final public const INACTIVE_DELETE_UNUSED = 3;
 
     /**
      * @var int
      */
-    public const NO_MAILING_NOT_SET = 0;
+    final public const NO_MAILING_NOT_SET = 0;
 
     /**
      * @var int
      */
-    public const NO_MAILING_NO_MAILING = 1;
+    final public const NO_MAILING_NO_MAILING = 1;
 
     /**
      * Type data template.

--- a/src/Type/ApiNotification.php
+++ b/src/Type/ApiNotification.php
@@ -20,62 +20,62 @@ class ApiNotification extends AbstractType implements TypeInterface
     /**
      * @var int
      */
-    public const EVENT_BOOKING_EXECUTED = 1;
+    final public const EVENT_BOOKING_EXECUTED = 1;
 
     /**
      * @var int
      */
-    public const EVENT_AVAILABLE_STOCK_CHANGED = 2;
+    final public const EVENT_AVAILABLE_STOCK_CHANGED = 2;
 
     /**
      * @var int
      */
-    public const EVENT_CUSTOMER_ORDER_CHANGED = 3;
+    final public const EVENT_CUSTOMER_ORDER_CHANGED = 3;
 
     /**
      * @var int
      */
-    public const EVENT_DELIVERY_CHANGED = 4;
+    final public const EVENT_DELIVERY_CHANGED = 4;
 
     /**
      * @var int
      */
-    public const EVENT_INVOICE_CHANGED = 5;
+    final public const EVENT_INVOICE_CHANGED = 5;
 
     /**
      * @var int
      */
-    public const EVENT_QUOTATION_CHANGED = 6;
+    final public const EVENT_QUOTATION_CHANGED = 6;
 
     /**
      * @var int
      */
-    public const EVENT_STOCK_CHANGED = 7;
+    final public const EVENT_STOCK_CHANGED = 7;
 
     /**
      * @var int
      */
-    public const EVENT_PRODUCT_CHANGED = 8;
+    final public const EVENT_PRODUCT_CHANGED = 8;
 
     /**
      * @var int
      */
-    public const EVENT_CUSTOMER_SUPPLIER_ADDRESS_MEMBER_CHANGED = 9;
+    final public const EVENT_CUSTOMER_SUPPLIER_ADDRESS_MEMBER_CHANGED = 9;
 
     /**
      * @var int
      */
-    public const INACTIVE_ACTIVE = 0;
+    final public const INACTIVE_ACTIVE = 0;
 
     /**
      * @var int
      */
-    public const INACTIVE_INACTIVE = 1;
+    final public const INACTIVE_INACTIVE = 1;
 
     /**
      * @var int
      */
-    public const INACTIVE_DELETE = 2;
+    final public const INACTIVE_DELETE = 2;
 
     /**
      * @var array

--- a/src/Type/Customer.php
+++ b/src/Type/Customer.php
@@ -68,55 +68,55 @@ class Customer extends AbstractType implements TypeInterface
     /**
      * @var int
      */
-    public const STATUS_ACTIVE = 0;
+    final public const STATUS_ACTIVE = 0;
     /**
      * @var int
      */
-    public const STATUS_INACTIVE = 1;
+    final public const STATUS_INACTIVE = 1;
 
     /**
      * @var int
      */
-    public const OUTPUT_MEDIUM_PRINT = 0;
+    final public const OUTPUT_MEDIUM_PRINT = 0;
     /**
      * @var int
      */
-    public const OUTPUT_MEDIUM_EMAIL = 1;
+    final public const OUTPUT_MEDIUM_EMAIL = 1;
     /**
      * @var int
      */
-    public const OUTPUT_MEDIUM_FAX = 2;
+    final public const OUTPUT_MEDIUM_FAX = 2;
     /**
      * @var int
      */
-    public const OUTPUT_MEDIUM_MAIL = 3;
+    final public const OUTPUT_MEDIUM_MAIL = 3;
 
     /**
      * @var int
      */
-    public const NO_DELIVERY_BLOCK = 0;
+    final public const NO_DELIVERY_BLOCK = 0;
     /**
      * @var int
      */
-    public const DELIVERY_BLOCK = 1;
+    final public const DELIVERY_BLOCK = 1;
 
     /**
      * @var int
      */
-    public const NO_CONSTRUCTION_SERVICE_PROVIDER = 0;
+    final public const NO_CONSTRUCTION_SERVICE_PROVIDER = 0;
     /**
      * @var int
      */
-    public const CONSTRUCTION_SERVICE_PROVIDER = 1;
+    final public const CONSTRUCTION_SERVICE_PROVIDER = 1;
 
     /**
      * @var int
      */
-    public const LANGUAGE_GERMAN = 0;
+    final public const LANGUAGE_GERMAN = 0;
     /**
      * @var int
      */
-    public const LANGUAGE_ENGLISH = 1;
+    final public const LANGUAGE_ENGLISH = 1;
 
     /**
      * Type data template.

--- a/src/Type/CustomerOrder.php
+++ b/src/Type/CustomerOrder.php
@@ -112,125 +112,125 @@ class CustomerOrder extends AbstractType implements TypeInterface
     /**
      * @var int
      */
-    public const PARTIAL_INVOICES_ALLOWED = 1;
+    final public const PARTIAL_INVOICES_ALLOWED = 1;
     /**
      * @var int
      */
-    public const PARTIAL_INVOICES_NOT_ALLOWED = 0;
+    final public const PARTIAL_INVOICES_NOT_ALLOWED = 0;
 
     /**
      * @var int
      */
-    public const PARTIAL_SHIPPING_ALLOWED = 1;
+    final public const PARTIAL_SHIPPING_ALLOWED = 1;
     /**
      * @var int
      */
-    public const PARTIAL_SHIPPING_NOT_ALLOWED = 0;
+    final public const PARTIAL_SHIPPING_NOT_ALLOWED = 0;
 
     /**
      * @var int
      */
-    public const NOT_DELETED = 0;
+    final public const NOT_DELETED = 0;
     /**
      * @var int
      */
-    public const DELETED = 1;
+    final public const DELETED = 1;
 
     /**
      * @var int
      */
-    public const STATUS_NEW = 0;
+    final public const STATUS_NEW = 0;
     /**
      * @var int
      */
-    public const STATUS_CONFIRMED = 10;
+    final public const STATUS_CONFIRMED = 10;
     /**
      * @var int
      */
-    public const STATUS_PARTIALLY_PAYED = 20;
+    final public const STATUS_PARTIALLY_PAYED = 20;
     /**
      * @var int
      */
-    public const STATUS_PAYMENT_CONFIRMED = 25;
+    final public const STATUS_PAYMENT_CONFIRMED = 25;
     /**
      * @var int
      */
-    public const STATUS_PAYED = 30;
+    final public const STATUS_PAYED = 30;
     /**
      * @var int
      */
-    public const STATUS_PARTIALLY_SHIPPED = 40;
+    final public const STATUS_PARTIALLY_SHIPPED = 40;
     /**
      * @var int
      */
-    public const STATUS_SHIPPED = 50;
+    final public const STATUS_SHIPPED = 50;
     /**
      * @var int
      */
-    public const STATUS_PARTIAL_DISCOUNT = 60;
+    final public const STATUS_PARTIAL_DISCOUNT = 60;
     /**
      * @var int
      */
-    public const STATUS_DISCOUNT = 70;
+    final public const STATUS_DISCOUNT = 70;
     /**
      * @var int
      */
-    public const STATUS_PARTIALLY_BILLED = 80;
+    final public const STATUS_PARTIALLY_BILLED = 80;
     /**
      * @var int
      */
-    public const STATUS_BILLED = 90;
+    final public const STATUS_BILLED = 90;
     /**
      * @var int
      */
-    public const STATUS_DONE = 100;
+    final public const STATUS_DONE = 100;
     /**
      * @var int
      */
-    public const STATUS_CANCELED = 1000;
+    final public const STATUS_CANCELED = 1000;
     /**
      * @var int
      */
-    public const STATUS_DELETED = 1010;
+    final public const STATUS_DELETED = 1010;
 
     /**
      * @var int
      */
-    public const LANGUAGE_GERMAN = 0;
+    final public const LANGUAGE_GERMAN = 0;
     /**
      * @var int
      */
-    public const LANGUAGE_ENGLISH = 1;
+    final public const LANGUAGE_ENGLISH = 1;
 
     /**
      * @var int
      */
-    public const POSITION_NORMAL = 0;
+    final public const POSITION_NORMAL = 0;
     /**
      * @var int
      */
-    public const POSITION_SUM = 1;
+    final public const POSITION_SUM = 1;
     /**
      * @var int
      */
-    public const POSITION_TEXT = 2;
+    final public const POSITION_TEXT = 2;
     /**
      * @var int
      */
-    public const POSITION_FREE = 3;
+    final public const POSITION_FREE = 3;
 
     /**
      * @var int
      */
-    public const TAX_RATE_FULL = 0;
+    final public const TAX_RATE_FULL = 0;
     /**
      * @var int
      */
-    public const TAX_RATE_REDUCED = 1;
+    final public const TAX_RATE_REDUCED = 1;
     /**
      * @var int
      */
-    public const TAX_RATE_TAXFREE = 2;
+    final public const TAX_RATE_TAXFREE = 2;
 
     /**
      * @var array

--- a/src/Type/Employee.php
+++ b/src/Type/Employee.php
@@ -31,8 +31,8 @@ namespace MarcusJaschen\Collmex\Type;
  */
 class Employee extends AbstractType implements TypeInterface
 {
-    public const TYPE_EMPLOYEE = 0;
-    public const TYPE_ENTREPRENEUR = 1;
+    final public const TYPE_EMPLOYEE = 0;
+    final public const TYPE_ENTREPRENEUR = 1;
 
     /**
      * @var array

--- a/src/Type/Invoice.php
+++ b/src/Type/Invoice.php
@@ -107,100 +107,100 @@ class Invoice extends AbstractType implements TypeInterface
     /**
      * @var int
      */
-    public const INVOICE_TYPE_INVOICE = 0;
+    final public const INVOICE_TYPE_INVOICE = 0;
     /**
      * @var int
      */
-    public const INVOICE_TYPE_CREDIT_MEMO = 1;
+    final public const INVOICE_TYPE_CREDIT_MEMO = 1;
     /**
      * @var int
      */
-    public const INVOICE_TYPE_DOWN_PAYMENT = 2;
+    final public const INVOICE_TYPE_DOWN_PAYMENT = 2;
     /**
      * @var int
      */
-    public const INVOICE_TYPE_CASH_SALE = 3;
+    final public const INVOICE_TYPE_CASH_SALE = 3;
     /**
      * @var int
      */
-    public const INVOICE_TYPE_CREDIT_FOR_RETURNS = 4;
+    final public const INVOICE_TYPE_CREDIT_FOR_RETURNS = 4;
     /**
      * @var int
      */
-    public const INVOICE_TYPE_PRO_FORMA_INVOICE = 5;
+    final public const INVOICE_TYPE_PRO_FORMA_INVOICE = 5;
 
     /**
      * @var int
      */
-    public const NOT_DELETED = 0;
+    final public const NOT_DELETED = 0;
     /**
      * @var int
      */
-    public const DELETED = 1;
+    final public const DELETED = 1;
 
     /**
      * @var int
      */
-    public const LANGUAGE_GERMAN = 0;
+    final public const LANGUAGE_GERMAN = 0;
     /**
      * @var int
      */
-    public const LANGUAGE_ENGLISH = 1;
+    final public const LANGUAGE_ENGLISH = 1;
 
     /**
      * @var int
      */
-    public const STATUS_NEW = 0;
+    final public const STATUS_NEW = 0;
     /**
      * @var int
      */
-    public const STATUS_TO_BOOK = 10;
+    final public const STATUS_TO_BOOK = 10;
     /**
      * @var int
      */
-    public const STATUS_OPEN = 20;
+    final public const STATUS_OPEN = 20;
     /**
      * @var int
      */
-    public const STATUS_REMINDED = 30;
+    final public const STATUS_REMINDED = 30;
     /**
      * @var int
      */
-    public const STATUS_DONE = 40;
+    final public const STATUS_DONE = 40;
     /**
      * @var int
      */
-    public const STATUS_DELETED = 100;
+    final public const STATUS_DELETED = 100;
 
     /**
      * @var int
      */
-    public const POSITION_NORMAL = 0;
+    final public const POSITION_NORMAL = 0;
     /**
      * @var int
      */
-    public const POSITION_SUM = 1;
+    final public const POSITION_SUM = 1;
     /**
      * @var int
      */
-    public const POSITION_TEXT = 2;
+    final public const POSITION_TEXT = 2;
     /**
      * @var int
      */
-    public const POSITION_FREE = 3;
+    final public const POSITION_FREE = 3;
 
     /**
      * @var int
      */
-    public const TAX_RATE_FULL = 0;
+    final public const TAX_RATE_FULL = 0;
     /**
      * @var int
      */
-    public const TAX_RATE_REDUCED = 1;
+    final public const TAX_RATE_REDUCED = 1;
     /**
      * @var int
      */
-    public const TAX_RATE_TAXFREE = 2;
+    final public const TAX_RATE_TAXFREE = 2;
 
     /**
      * Type data template.

--- a/src/Type/InvoiceGet.php
+++ b/src/Type/InvoiceGet.php
@@ -30,20 +30,20 @@ class InvoiceGet extends AbstractType implements TypeInterface
     /**
      * @var int
      */
-    public const FORMAT_CSV = 0;
+    final public const FORMAT_CSV = 0;
     /**
      * @var int
      */
-    public const FORMAT_ZIP = 1;
+    final public const FORMAT_ZIP = 1;
 
     /**
      * @var int
      */
-    public const STATIONARY_INCLUDE = 0;
+    final public const STATIONARY_INCLUDE = 0;
     /**
      * @var int
      */
-    public const STATIONARY_EXCLUDE = 1;
+    final public const STATIONARY_EXCLUDE = 1;
 
     /**
      * @var array

--- a/src/Type/InvoiceOutput.php
+++ b/src/Type/InvoiceOutput.php
@@ -26,62 +26,62 @@ class InvoiceOutput extends AbstractType implements TypeInterface
     /**
      * @var int
      */
-    public const OUTPUT_MEDIUM_PRINT = 0;
+    final public const OUTPUT_MEDIUM_PRINT = 0;
 
     /**
      * @var int
      */
-    public const OUTPUT_MEDIUM_EMAIL = 1;
+    final public const OUTPUT_MEDIUM_EMAIL = 1;
 
     /**
      * @var int
      */
-    public const OUTPUT_MEDIUM_FAX = 2;
+    final public const OUTPUT_MEDIUM_FAX = 2;
 
     /**
      * @var int
      */
-    public const OUTPUT_MEDIUM_MAIL = 3;
+    final public const OUTPUT_MEDIUM_MAIL = 3;
 
     /**
      * @var int
      */
-    public const OUTPUT_MEDIUM_EMAIL_SIGNED = 4;
+    final public const OUTPUT_MEDIUM_EMAIL_SIGNED = 4;
 
     /**
      * @var int
      */
-    public const OUTPUT_MEDIUM_NO_OUTPUT = 100;
+    final public const OUTPUT_MEDIUM_NO_OUTPUT = 100;
 
     /**
      * @var int
      */
-    public const ALSO_DELETED_NO_DELETED = 0;
+    final public const ALSO_DELETED_NO_DELETED = 0;
 
     /**
      * @var int
      */
-    public const ALSO_DELETED_DELETED = 1;
+    final public const ALSO_DELETED_DELETED = 1;
 
     /**
      * @var int
      */
-    public const DONT_BOOK_BOOK = 0;
+    final public const DONT_BOOK_BOOK = 0;
 
     /**
      * @var int
      */
-    public const DONT_BOOK_NO_BOOK = 1;
+    final public const DONT_BOOK_NO_BOOK = 1;
 
     /**
      * @var int
      */
-    public const OUTPUT_REQUIRED_REQUIRED = 1;
+    final public const OUTPUT_REQUIRED_REQUIRED = 1;
 
     /**
      * @var int
      */
-    public const OUTPUT_REQUIRED_NOT_REQUIRED = 0;
+    final public const OUTPUT_REQUIRED_NOT_REQUIRED = 0;
 
     /**
      * @var array

--- a/src/Type/InvoiceOutputSet.php
+++ b/src/Type/InvoiceOutputSet.php
@@ -18,27 +18,27 @@ class InvoiceOutputSet extends AbstractType implements TypeInterface
     /**
      * @var int
      */
-    public const OUTPUT_MEDIUM_PRINT = 0;
+    final public const OUTPUT_MEDIUM_PRINT = 0;
     /**
      * @var int
      */
-    public const OUTPUT_MEDIUM_EMAIL = 1;
+    final public const OUTPUT_MEDIUM_EMAIL = 1;
     /**
      * @var int
      */
-    public const OUTPUT_MEDIUM_FAX = 2;
+    final public const OUTPUT_MEDIUM_FAX = 2;
     /**
      * @var int
      */
-    public const OUTPUT_MEDIUM_MAIL = 3;
+    final public const OUTPUT_MEDIUM_MAIL = 3;
     /**
      * @var int
      */
-    public const OUTPUT_MEDIUM_EMAIL_SIGNED = 4;
+    final public const OUTPUT_MEDIUM_EMAIL_SIGNED = 4;
     /**
      * @var int
      */
-    public const OUTPUT_MEDIUM_NO_OUTPUT = 100;
+    final public const OUTPUT_MEDIUM_NO_OUTPUT = 100;
 
     /**
      * @var array

--- a/src/Type/Member.php
+++ b/src/Type/Member.php
@@ -53,55 +53,55 @@ class Member extends AbstractType implements TypeInterface
     /**
      * @var int
      */
-    public const STATUS_ACTIVE = 0;
+    final public const STATUS_ACTIVE = 0;
     /**
      * @var int
      */
-    public const STATUS_INACTIVE = 1;
+    final public const STATUS_INACTIVE = 1;
 
     /**
      * @var int
      */
-    public const OUTPUT_MEDIUM_PRINT = 0;
+    final public const OUTPUT_MEDIUM_PRINT = 0;
     /**
      * @var int
      */
-    public const OUTPUT_MEDIUM_EMAIL = 1;
+    final public const OUTPUT_MEDIUM_EMAIL = 1;
     /**
      * @var int
      */
-    public const OUTPUT_MEDIUM_FAX = 2;
+    final public const OUTPUT_MEDIUM_FAX = 2;
     /**
      * @var int
      */
-    public const OUTPUT_MEDIUM_MAIL = 3;
+    final public const OUTPUT_MEDIUM_MAIL = 3;
 
     /**
      * @var int
      */
-    public const NO_DELIVERY_BLOCK = 0;
+    final public const NO_DELIVERY_BLOCK = 0;
     /**
      * @var int
      */
-    public const DELIVERY_BLOCK = 1;
+    final public const DELIVERY_BLOCK = 1;
 
     /**
      * @var int
      */
-    public const NO_CONSTRUCTION_SERVICE_PROVIDER = 0;
+    final public const NO_CONSTRUCTION_SERVICE_PROVIDER = 0;
     /**
      * @var int
      */
-    public const CONSTRUCTION_SERVICE_PROVIDER = 1;
+    final public const CONSTRUCTION_SERVICE_PROVIDER = 1;
 
     /**
      * @var int
      */
-    public const LANGUAGE_GERMAN = 0;
+    final public const LANGUAGE_GERMAN = 0;
     /**
      * @var int
      */
-    public const LANGUAGE_ENGLISH = 1;
+    final public const LANGUAGE_ENGLISH = 1;
 
     /**
      * Type data template.

--- a/src/Type/Product.php
+++ b/src/Type/Product.php
@@ -83,160 +83,160 @@ class Product extends AbstractType implements TypeInterface
     /**
      * @var int
      */
-    public const TAX_RATE_FULL = 0;
+    final public const TAX_RATE_FULL = 0;
     /**
      * @var int
      */
-    public const TAX_RATE_REDUCED = 1;
+    final public const TAX_RATE_REDUCED = 1;
     /**
      * @var int
      */
-    public const TAX_RATE_TAXFREE = 2;
+    final public const TAX_RATE_TAXFREE = 2;
 
     /**
      * @var int
      */
-    public const BUY_TAX_RATE_FULL = 0;
+    final public const BUY_TAX_RATE_FULL = 0;
     /**
      * @var int
      */
-    public const BUY_TAX_RATE_REDUCED = 1;
+    final public const BUY_TAX_RATE_REDUCED = 1;
     /**
      * @var int
      */
-    public const BUY_TAX_RATE_TAXFREE = 2;
+    final public const BUY_TAX_RATE_TAXFREE = 2;
 
     /**
      * @var int
      */
-    public const PRODUCT_TYPE_GOODS = 0;
+    final public const PRODUCT_TYPE_GOODS = 0;
     /**
      * @var int
      */
-    public const PRODUCT_TYPE_SERVICE = 1;
+    final public const PRODUCT_TYPE_SERVICE = 1;
     /**
      * @var int
      */
-    public const PRODUCT_TYPE_MEMBERSHIP_FEE = 2;
+    final public const PRODUCT_TYPE_MEMBERSHIP_FEE = 2;
     /**
      * @var int
      */
-    public const PRODUCT_TYPE_CONSTRUCTION_SERVICE = 3;
+    final public const PRODUCT_TYPE_CONSTRUCTION_SERVICE = 3;
     /**
      * @var int
      */
-    public const PRODUCT_TYPE_GOODS_CUSTOMER_TAX = 4;
+    final public const PRODUCT_TYPE_GOODS_CUSTOMER_TAX = 4;
 
     /**
      * @var int
      */
-    public const INACTIVE_PRODUCT_ACTIVE = 0;
+    final public const INACTIVE_PRODUCT_ACTIVE = 0;
     /**
      * @var int
      */
-    public const INACTIVE_PRODUCT_INACTIVE = 1;
+    final public const INACTIVE_PRODUCT_INACTIVE = 1;
     /**
      * @var int
      */
-    public const INACTIVE_PRODUCT_DELETE = 2;
+    final public const INACTIVE_PRODUCT_DELETE = 2;
     /**
      * @var int
      */
-    public const INACTIVE_PRODUCT_DELETE_IF_INACTIVE = 3;
+    final public const INACTIVE_PRODUCT_DELETE_IF_INACTIVE = 3;
 
     /**
      * @var int
      */
-    public const LOT_MANDATORY = 0;
+    final public const LOT_MANDATORY = 0;
 
     /**
      * @var int
      */
-    public const TEXT_PLAIN = 0;
+    final public const TEXT_PLAIN = 0;
     /**
      * @var int
      */
-    public const TEXT_HTML = 1;
+    final public const TEXT_HTML = 1;
 
     /**
      * @var int
      */
-    public const PROCUREMENT_SHOPPING = 0;
+    final public const PROCUREMENT_SHOPPING = 0;
     /**
      * @var int
      */
-    public const PROCUREMENT_PRODUCTION = 10;
+    final public const PROCUREMENT_PRODUCTION = 10;
 
     /**
      * @var int
      */
-    public const LABOR_COSTS_REFERENCE_AMOUNT = 1;
+    final public const LABOR_COSTS_REFERENCE_AMOUNT = 1;
 
     /**
      * @var int
      */
-    public const COSTING_AUTOMATIC = 0;
+    final public const COSTING_AUTOMATIC = 0;
     /**
      * @var int
      */
-    public const COSTING_MANUAL = 0;
+    final public const COSTING_MANUAL = 0;
 
     /**
      * @var int
      */
-    public const BASIC_UNIT_NO_UNIT = 0;
+    final public const BASIC_UNIT_NO_UNIT = 0;
     /**
      * @var int
      */
-    public const BASIC_UNIT_KILOGRAM = 1;
+    final public const BASIC_UNIT_KILOGRAM = 1;
     /**
      * @var int
      */
-    public const BASIC_UNIT_LITER = 2;
+    final public const BASIC_UNIT_LITER = 2;
     /**
      * @var int
      */
-    public const BASIC_UNIT_CUBIC_METER = 3;
+    final public const BASIC_UNIT_CUBIC_METER = 3;
     /**
      * @var int
      */
-    public const BASIC_UNIT_METER = 4;
+    final public const BASIC_UNIT_METER = 4;
     /**
      * @var int
      */
-    public const BASIC_UNIT_SQUARE_METER = 5;
+    final public const BASIC_UNIT_SQUARE_METER = 5;
     /**
      * @var int
      */
-    public const BASIC_UNIT_PIECE = 6;
+    final public const BASIC_UNIT_PIECE = 6;
 
     /**
      * @var int
      */
-    public const DELIVERY_RELEVANCE_NO = 0;
+    final public const DELIVERY_RELEVANCE_NO = 0;
     /**
      * @var int
      */
-    public const DELIVERY_RELEVANCE_YES = 1;
+    final public const DELIVERY_RELEVANCE_YES = 1;
 
     /**
      * @var int
      */
-    public const DIRECT_DELIVERY_NO = 0;
+    final public const DIRECT_DELIVERY_NO = 0;
     /**
      * @var int
      */
-    public const DIRECT_DELIVERY_YES = 1;
+    final public const DIRECT_DELIVERY_YES = 1;
 
     /**
      * @var int
      */
-    public const STOCK_MANAGEMENT_YES = 0;
+    final public const STOCK_MANAGEMENT_YES = 0;
 
     /**
      * @var int
      */
-    public const STOCK_MANAGEMENT_NO = 1;
+    final public const STOCK_MANAGEMENT_NO = 1;
 
     /**
      * Type data template.

--- a/src/Type/ProductGet.php
+++ b/src/Type/ProductGet.php
@@ -25,11 +25,11 @@ class ProductGet extends AbstractType implements TypeInterface
     /**
      * @var int
      */
-    public const ONLY_WITH_PRICE = 1;
+    final public const ONLY_WITH_PRICE = 1;
     /**
      * @var int
      */
-    public const NOTONLY_WITH_PRICE = 0;
+    final public const NOTONLY_WITH_PRICE = 0;
 
     /**
      * @var array

--- a/src/Type/Revenue.php
+++ b/src/Type/Revenue.php
@@ -43,49 +43,49 @@ class Revenue extends AbstractType implements TypeInterface
     /**
      * @var int
      */
-    public const INVOICE_TYPE_STANDARD = 0;
+    final public const INVOICE_TYPE_STANDARD = 0;
     /**
      * @var int
      */
-    public const INVOICE_TYPE_CREDIT_MEMO = 1;
+    final public const INVOICE_TYPE_CREDIT_MEMO = 1;
     /**
      * @var int
      */
-    public const INVOICE_TYPE_DOWN_PAYMENT = 2;
+    final public const INVOICE_TYPE_DOWN_PAYMENT = 2;
 
     /**
      * @var null
      */
-    public const CANCELATION_TYPE_NO_CANCELATION = null;
+    final public const CANCELATION_TYPE_NO_CANCELATION = null;
     /**
      * @var int
      */
-    public const CANCELATION_TYPE_CANCELATION = 1;
+    final public const CANCELATION_TYPE_CANCELATION = 1;
 
     /**
      * @var int
      */
-    public const REVENUE_TYPE_EXPORT = 10;
+    final public const REVENUE_TYPE_EXPORT = 10;
     /**
      * @var int
      */
-    public const REVENUE_TYPE_INNER_COMMUNITY = 11;
+    final public const REVENUE_TYPE_INNER_COMMUNITY = 11;
     /**
      * @var int
      */
-    public const REVENUE_TYPE_NO_TAX_EU = 12;
+    final public const REVENUE_TYPE_NO_TAX_EU = 12;
     /**
      * @var int
      */
-    public const REVENUE_TYPE_NO_TAX = 13;
+    final public const REVENUE_TYPE_NO_TAX = 13;
     /**
      * @var int
      */
-    public const REVENUE_TYPE_TAX = 14;
+    final public const REVENUE_TYPE_TAX = 14;
     /**
      * @var int
      */
-    public const REVENUE_TYPE_NO_TAX_3RD_PARTY_COUNTRY = 15;
+    final public const REVENUE_TYPE_NO_TAX_3RD_PARTY_COUNTRY = 15;
 
     /**
      * @var array

--- a/src/Type/SalesOrderGet.php
+++ b/src/Type/SalesOrderGet.php
@@ -27,33 +27,33 @@ class SalesOrderGet extends AbstractType implements TypeInterface
     /**
      * @var int
      */
-    public const FORMAT_CSV = 0;
+    final public const FORMAT_CSV = 0;
     /**
      * @var int
      */
-    public const FORMAT_ZIP = 1;
+    final public const FORMAT_ZIP = 1;
 
     /**
      * useable for 'changed_only' and 'only_created_by_system'.
      *
      * @var int
      */
-    public const FILTER_ON = 1;
+    final public const FILTER_ON = 1;
     /**
      * useable for 'changed_only' and 'only_created_by_system'.
      *
      * @var int
      */
-    public const FILTER_OFF = 0;
+    final public const FILTER_OFF = 0;
 
     /**
      * @var int
      */
-    public const WITH_LETTER_PAPER = 0;
+    final public const WITH_LETTER_PAPER = 0;
     /**
      * @var int
      */
-    public const NO_LETTER_PAPER = 1;
+    final public const NO_LETTER_PAPER = 1;
 
     /**
      * @var array

--- a/src/Type/ShipmentOrdersGet.php
+++ b/src/Type/ShipmentOrdersGet.php
@@ -26,43 +26,43 @@ class ShipmentOrdersGet extends AbstractType implements TypeInterface
     /**
      * @var int
      */
-    public const SHIPMENT_HANDOVER_ID_UNIVERSAL_CSV = 1;
+    final public const SHIPMENT_HANDOVER_ID_UNIVERSAL_CSV = 1;
     /**
      * @var int
      */
-    public const SHIPMENT_HANDOVER_ID_DHL_ONLINE_FRANKING = 2;
+    final public const SHIPMENT_HANDOVER_ID_DHL_ONLINE_FRANKING = 2;
     /**
      * @var int
      */
-    public const SHIPMENT_HANDOVER_ID_DHL_INTRASHIP = 3;
+    final public const SHIPMENT_HANDOVER_ID_DHL_INTRASHIP = 3;
     /**
      * @var int
      */
-    public const SHIPMENT_HANDOVER_ID_FULFILLMENT_SERVICE_PROVIDER = 4;
+    final public const SHIPMENT_HANDOVER_ID_FULFILLMENT_SERVICE_PROVIDER = 4;
     /**
      * @var int
      */
-    public const SHIPMENT_HANDOVER_ID_YOUR_GLS = 5;
+    final public const SHIPMENT_HANDOVER_ID_YOUR_GLS = 5;
     /**
      * @var int
      */
-    public const SHIPMENT_HANDOVER_ID_HERMES = 6;
+    final public const SHIPMENT_HANDOVER_ID_HERMES = 6;
     /**
      * @var int
      */
-    public const SHIPMENT_HANDOVER_ID_AMAZON_FBA = 7;
+    final public const SHIPMENT_HANDOVER_ID_AMAZON_FBA = 7;
     /**
      * @var int
      */
-    public const SHIPMENT_HANDOVER_ID_GERMAN_POST_INTERNET_STAMP = 8;
+    final public const SHIPMENT_HANDOVER_ID_GERMAN_POST_INTERNET_STAMP = 8;
     /**
      * @var int
      */
-    public const SHIPMENT_HANDOVER_ID_MY_DPD_BUSINESS = 9;
+    final public const SHIPMENT_HANDOVER_ID_MY_DPD_BUSINESS = 9;
     /**
      * @var int
      */
-    public const SHIPMENT_HANDOVER_ID_DHL_BUSINESS_CLIENT_PORTAL = 10;
+    final public const SHIPMENT_HANDOVER_ID_DHL_BUSINESS_CLIENT_PORTAL = 10;
 
     /**
      * @var array

--- a/src/Type/StockChange.php
+++ b/src/Type/StockChange.php
@@ -47,28 +47,28 @@ class StockChange extends AbstractType implements TypeInterface
     /**
      * @var int
      */
-    public const STOCK_CHANGE_TYPE_WITHDRAWAL = 0;
+    final public const STOCK_CHANGE_TYPE_WITHDRAWAL = 0;
     /**
      * @var int
      */
-    public const STOCK_CHANGE_TYPE_INPUT = 1;
+    final public const STOCK_CHANGE_TYPE_INPUT = 1;
     /**
      * @var int
      */
-    public const STOCK_CHANGE_TYPE_TRANSFER = 2;
+    final public const STOCK_CHANGE_TYPE_TRANSFER = 2;
     /**
      * @var int
      */
-    public const STOCK_CHANGE_TYPE_INVENTORY = 3;
+    final public const STOCK_CHANGE_TYPE_INVENTORY = 3;
 
     /**
      * @var int
      */
-    public const DESTINATION_STOCK_TYPE_FREE = 0;
+    final public const DESTINATION_STOCK_TYPE_FREE = 0;
     /**
      * @var int
      */
-    public const DESTINATION_STOCK_TYPE_LOCKED = 1;
+    final public const DESTINATION_STOCK_TYPE_LOCKED = 1;
 
     /**
      * @var array

--- a/src/Type/StockGet.php
+++ b/src/Type/StockGet.php
@@ -22,9 +22,9 @@ namespace MarcusJaschen\Collmex\Type;
  */
 class StockGet extends AbstractType implements TypeInterface
 {
-    public const TYPE_FREI = 0;
-    public const TYPE_GESPERRT = 1;
-    public const TYPE_FBA_BESTAND = 2;
+    final public const TYPE_FREI = 0;
+    final public const TYPE_GESPERRT = 1;
+    final public const TYPE_FBA_BESTAND = 2;
 
     /**
      * @var array

--- a/src/Type/Subscription.php
+++ b/src/Type/Subscription.php
@@ -28,35 +28,35 @@ class Subscription extends AbstractType implements TypeInterface
     /**
      * @var int
      */
-    public const INTERVAL_YEAR = 0;
+    final public const INTERVAL_YEAR = 0;
     /**
      * @var int
      */
-    public const INTERVAL_HALF_YEAR = 1;
+    final public const INTERVAL_HALF_YEAR = 1;
     /**
      * @var int
      */
-    public const INTERVAL_QUARTER = 2;
+    final public const INTERVAL_QUARTER = 2;
     /**
      * @var int
      */
-    public const INTERVAL_MONTH = 3;
+    final public const INTERVAL_MONTH = 3;
     /**
      * @var int
      */
-    public const INTERVAL_YEAR_PREPAID = 4;
+    final public const INTERVAL_YEAR_PREPAID = 4;
     /**
      * @var int
      */
-    public const INTERVAL_HALF_YEAR_PREPAID = 5;
+    final public const INTERVAL_HALF_YEAR_PREPAID = 5;
     /**
      * @var int
      */
-    public const INTERVAL_QUARTER_PREPAID = 6;
+    final public const INTERVAL_QUARTER_PREPAID = 6;
     /**
      * @var int
      */
-    public const INTERVAL_MONTH_PREPAID = 7;
+    final public const INTERVAL_MONTH_PREPAID = 7;
 
     /**
      * Type data template.

--- a/src/Type/SubscriptionGet.php
+++ b/src/Type/SubscriptionGet.php
@@ -25,15 +25,15 @@ class SubscriptionGet extends AbstractType implements TypeInterface
     /**
      * @var int
      */
-    public const FILTER_ALL = 0;
+    final public const FILTER_ALL = 0;
     /**
      * @var int
      */
-    public const FILTER_CURRENTLY_VALID = 1;
+    final public const FILTER_CURRENTLY_VALID = 1;
     /**
      * @var int
      */
-    public const FILTER_CHANGED_ONLY = 1;
+    final public const FILTER_CHANGED_ONLY = 1;
 
     /**
      * Type data template.

--- a/src/Type/Supplier.php
+++ b/src/Type/Supplier.php
@@ -53,13 +53,13 @@ namespace MarcusJaschen\Collmex\Type;
  */
 class Supplier extends AbstractType implements TypeInterface
 {
-    public const INACTIVE_STATE_ACTIVE = 0;
-    public const INACTIVE_STATE_INACTIVE = 1;
-    public const INACTIVE_STATE_DELETE = 2;
-    public const INACTIVE_STATE_DELETE_IF_UNUSED = 3;
+    final public const INACTIVE_STATE_ACTIVE = 0;
+    final public const INACTIVE_STATE_INACTIVE = 1;
+    final public const INACTIVE_STATE_DELETE = 2;
+    final public const INACTIVE_STATE_DELETE_IF_UNUSED = 3;
 
-    public const LANGUAGE_GERMAN = 0;
-    public const LANGUAGE_ENGLISH = 1;
+    final public const LANGUAGE_GERMAN = 0;
+    final public const LANGUAGE_ENGLISH = 1;
 
     /**
      * Type data template.

--- a/src/Type/SupplierCredit.php
+++ b/src/Type/SupplierCredit.php
@@ -67,63 +67,63 @@ class SupplierCredit extends AbstractType implements TypeInterface
     /**
      * @var int
      */
-    public const NOT_DELETED = 0;
+    final public const NOT_DELETED = 0;
     /**
      * @var int
      */
-    public const DELETED = 1;
+    final public const DELETED = 1;
 
     /**
      * @var int
      */
-    public const LANGUAGE_GERMAN = 0;
+    final public const LANGUAGE_GERMAN = 0;
     /**
      * @var int
      */
-    public const LANGUAGE_ENGLISH = 1;
+    final public const LANGUAGE_ENGLISH = 1;
 
     /**
      * @var int
      */
-    public const STATUS_NEW = 0;
+    final public const STATUS_NEW = 0;
     /**
      * @var int
      */
-    public const STATUS_OPEN = 10;
+    final public const STATUS_OPEN = 10;
     /**
      * @var int
      */
-    public const STATUS_PARTIALLY_SHIPPED = 20;
+    final public const STATUS_PARTIALLY_SHIPPED = 20;
     /**
      * @var int
      */
-    public const STATUS_DONE = 30;
+    final public const STATUS_DONE = 30;
     /**
      * @var int
      */
-    public const STATUS_DELETED = 40;
+    final public const STATUS_DELETED = 40;
 
     /**
      * @var int
      */
-    public const POSITION_NORMAL = 0;
+    final public const POSITION_NORMAL = 0;
     /**
      * @var int
      */
-    public const POSITION_TEXT = 2;
+    final public const POSITION_TEXT = 2;
 
     /**
      * @var int
      */
-    public const TAX_RATE_FULL = 0;
+    final public const TAX_RATE_FULL = 0;
     /**
      * @var int
      */
-    public const TAX_RATE_REDUCED = 1;
+    final public const TAX_RATE_REDUCED = 1;
     /**
      * @var int
      */
-    public const TAX_RATE_TAXFREE = 2;
+    final public const TAX_RATE_TAXFREE = 2;
 
     /**
      * @var array

--- a/src/Type/SupplierInvoice.php
+++ b/src/Type/SupplierInvoice.php
@@ -9,11 +9,11 @@ class SupplierInvoice extends AbstractType implements TypeInterface
     /**
      * @var null
      */
-    public const CANCELATION_TYPE_NO_CANCELATION = null;
+    final public const CANCELATION_TYPE_NO_CANCELATION = null;
     /**
      * @var int
      */
-    public const CANCELATION_TYPE_CANCELATION = 1;
+    final public const CANCELATION_TYPE_CANCELATION = 1;
 
     /**
      * @var array

--- a/src/Type/Validator/Date.php
+++ b/src/Type/Validator/Date.php
@@ -20,7 +20,7 @@ class Date implements ValidatorInterface
     {
         try {
             $date = $this->createDateInstance($value);
-        } catch (\InvalidArgumentException $exception) {
+        } catch (\InvalidArgumentException) {
             return false;
         }
 
@@ -37,6 +37,6 @@ class Date implements ValidatorInterface
             return \DateTime::createFromFormat('d.m.Y', $value);
         }
 
-        throw new \InvalidArgumentException('Invalid date format: ' . $value, 3203218841);
+        throw new \InvalidArgumentException('Invalid date format: ' . $value, 3_203_218_841);
     }
 }

--- a/src/TypeFactory.php
+++ b/src/TypeFactory.php
@@ -43,9 +43,7 @@ use MarcusJaschen\Collmex\Type\TrackingNumber;
 use MarcusJaschen\Collmex\Type\Voucher;
 
 /**
- * Type Factory for Collmex Response Data.
- *
- * @author   Marcus Jaschen <mail@marcusjaschen.de>
+ * Type Factory for Collmex response data: Builds the type object for the given data.
  */
 class TypeFactory
 {
@@ -91,12 +89,6 @@ class TypeFactory
     ];
 
     /**
-     * Builds the type object for the given data.
-     *
-     * @param array $data
-     *
-     * @return Type\AbstractType
-     *
      * @throws InvalidTypeIdentifierException
      */
     public function getType(array $data): Type\AbstractType
@@ -106,7 +98,7 @@ class TypeFactory
         if (!isset(self::RECORD_TYPE_CLASS_MAP[$recordTypeIdentifier])) {
             throw new InvalidTypeIdentifierException(
                 'Invalid/Unsupported Record Type Identifier: ' . $recordTypeIdentifier,
-                8186126281
+                8_186_126_281
             );
         }
 
@@ -116,6 +108,6 @@ class TypeFactory
             return new $class($data);
         }
 
-        throw new InvalidTypeIdentifierException('Undefined Class: ' . $class, 4512716533);
+        throw new InvalidTypeIdentifierException('Undefined Class: ' . $class, 4_512_716_533);
     }
 }

--- a/src/TypeFactory.php
+++ b/src/TypeFactory.php
@@ -89,6 +89,7 @@ class TypeFactory
     ];
 
     /**
+     * @param array<int, string> $data
      * @throws InvalidTypeIdentifierException
      */
     public function getType(array $data): Type\AbstractType

--- a/tests/Integration/Response/ZipResponseTest.php
+++ b/tests/Integration/Response/ZipResponseTest.php
@@ -20,15 +20,9 @@ use Symfony\Component\Finder\Finder;
  */
 class ZipResponseTest extends TestCase
 {
-    /**
-     * @var Parser
-     */
-    private $parser = null;
+    private ?\MarcusJaschen\Collmex\Csv\Parser $parser = null;
 
-    /**
-     * @var string
-     */
-    private $zipPath = '';
+    private string $zipPath = '';
 
     protected function setUp(): void
     {
@@ -47,8 +41,6 @@ class ZipResponseTest extends TestCase
     /**
      * Creates a ZIP file that contains a file with the given file name and contents.
      *
-     * @param string $fileName
-     * @param string $contents
      *
      * @return string the ZIP file contents
      *
@@ -59,7 +51,7 @@ class ZipResponseTest extends TestCase
         $zip = new \ZipArchive();
         $openStatus = $zip->open($this->zipPath, \ZipArchive::CREATE | \ZipArchive::EXCL);
         if (!$openStatus) {
-            throw new \RuntimeException('Could not open ZIP.', 1557497112);
+            throw new \RuntimeException('Could not open ZIP.', 1_557_497_112);
         }
         $zip->addFromString($fileName, $contents);
         $zip->close();

--- a/tests/Unit/CollmexField/DateTest.php
+++ b/tests/Unit/CollmexField/DateTest.php
@@ -49,7 +49,7 @@ class DateTest extends TestCase
     public function testConvertInvalidFormatToDateTime(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionCode(3746303620);
+        $this->expectExceptionCode(3_746_303_620);
 
         Date::toDateTime('09/21/2022');
     }


### PR DESCRIPTION
- add support for PHP 8.3
- remove support for PHP 7.x and PHP 8.0
- minimum required version is PHP 8.1
- increase PHP version requirement for Composer
- migrate PHPUnit config to 10.x
- use proper type hints for attributes, arguments and return values
- remove redundant doc block contents
- update ignore file
- use constructor property promotion
- set `null` as default attribute values
- mark class constants as `final`
- update Laravel service provider (register services which use the proper interface name for binding)
- remove unused exception
- remove no longer used class import
- update README + change log
- wrap long lines
- remove unused exception variable
- throw exception when JSON encoding fails
- use `::class` keyword instead of `get_class()`
- use arrow functions where applicable
- use `CurlHandle` instead of `resource` type
- use separators in large integers
- update Psalm config
- `send()` methods return `ResponseInterface` instead of concrete implementation