### PR TITLE
remove unneeded condition

### DIFF
--- a/src/Client/Curl.php
+++ b/src/Client/Curl.php
@@ -53,9 +53,7 @@ class Curl extends AbstractClient implements ClientInterface
 
     protected function destroyCurl(): void
     {
-        if (!empty($this->curl)) {
-            curl_close($this->curl);
-        }
+        curl_close($this->curl);
     }
 
     /**


### PR DESCRIPTION
check is always true (enforced by strict typing)