### PR TITLE
Use the development PHP INI on CI

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -32,6 +32,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
+          ini-file: development
           coverage: xdebug
           tools: pecl
           extensions: curl,fileinfo,zip


### PR DESCRIPTION
This will allow us to see (and fail on) PHP notices and warnings.