### PR TITLE
Disable Xdebug on CI

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -32,7 +32,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
-          coverage: xdebug
+          coverage: none
           tools: pecl
           extensions: curl,fileinfo,zip
 


### PR DESCRIPTION
As long as we are not collection code coverage data, we can avoid loading Xdebug and avoid the (albeit small) performance penalty.