### PR TITLE
Added new fields from Collmex API for types Member and query MemberGet

### DIFF
--- a/src/Type/Member.php
+++ b/src/Type/Member.php
@@ -7,8 +7,9 @@ namespace MarcusJaschen\Collmex\Type;
 /**
  * Collmex Member Type.
  *
- * @author    Sebastian Gunreben
+ * @author   Sebastian Gunreben
  * @author   Marcus Jaschen <mail@marcusjaschen.de>
+ * @author   Matthieu-P. Schapranow
  *
  * @property $type_identifier
  * @property $customer_id
@@ -47,6 +48,7 @@ namespace MarcusJaschen\Collmex\Type;
  * @property $payment_via
  * @property $printout_language
  * @property $cost_center
+ * @property $no_mailings
  */
 class Member extends AbstractType implements TypeInterface
 {
@@ -154,6 +156,7 @@ class Member extends AbstractType implements TypeInterface
         'payment_via' => null,
         'printout_language' => null,
         'cost_center' => null,
+        'no_mailings' => null,
     ];
 
     /**

--- a/src/Type/MemberGet.php
+++ b/src/Type/MemberGet.php
@@ -7,8 +7,9 @@ namespace MarcusJaschen\Collmex\Type;
 /**
  * Collmex Customer Get Type.
  *
- * @author    Sebastian Gunreben
- * @author    Marcus Jaschen <mail@marcusjaschen.de>
+ * @author   Sebastian Gunreben
+ * @author   Marcus Jaschen <mail@marcusjaschen.de>
+ * @author   Matthieu-P. Schapranow
  *
  * @property $type_identifier
  * @property $customer_id
@@ -19,6 +20,13 @@ namespace MarcusJaschen\Collmex\Type;
  * @property $exited_too
  * @property $changed_only
  * @property $system_name
+ * @property $reporting_date
+ * @property $entrance_date_from
+ * @property $entrance_date_to
+ * @property $exit_date_from
+ * @property $exit_date_to
+ * @property $birthday_from
+ * @property $birthday_to
  */
 class MemberGet extends AbstractType implements TypeInterface
 {
@@ -26,15 +34,26 @@ class MemberGet extends AbstractType implements TypeInterface
      * @var array
      */
     protected $template = [
+        // 1
         'type_identifier' => 'MEMBER_GET',
         'customer_id' => null,
         'client_id' => null,
         'query' => null,
+        // 5
         'zipcode' => null,
         'address_group_id' => null,
         'exited_too' => null,
         'changed_only' => null,
         'system_name' => null,
+        // 10
+        'reporting_date' => null,
+        'entrance_date_from' => null,
+        'entrance_date_to' => null,
+        'exit_date_from' => null,
+        'exit_date_to' => null,
+        // 15
+        'birthday_from' => null,
+        'birthday_to' => null,
     ];
 
     /**

--- a/src/Type/MemberGet.php
+++ b/src/Type/MemberGet.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace MarcusJaschen\Collmex\Type;
 
 /**
- * Collmex Customer Get Type.
+ * Collmex Member Get Type.
  *
  * @author   Sebastian Gunreben
  * @author   Marcus Jaschen <mail@marcusjaschen.de>


### PR DESCRIPTION
The query ```MemberGet``` was extended by ```reporting_date``` and by the date ranges (from, to) for attributes ```entrance_date, exit_date, birthday```: 
```
entrance_date_from
entrance_date_to
exit_date_from
exit_date_to
birthday_from
birthday_to
```
Furthermore, the ```Member``` type was extended by the attribute ```no_mailings```.