### PR TITLE
[TASK] Block Dependabot from updating Symfony components

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,5 +19,7 @@ updates:
       day: wednesday
       time: "09:00"
       timezone: "Europe/Berlin"
+    ignore:
+      - dependency-name: "symfony/*"
     open-pull-requests-limit: 10
     target-branch: main


### PR DESCRIPTION
We will have multi-version dependencies for the Symfony components, and Dependabot would shrink them into single-version dependencies.