### PR TITLE
[TASK] Ensure compatibility with all supported Symfony versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/)
 principles.
 
+## [3.2.0]
+
+### Added
+
+- Ensure compatibility with all currently supported Symfony versions (#304)
+
 ## [3.1.0]
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -30,10 +30,10 @@
         "ext-fileinfo": "*",
         "ext-json": "*",
         "ext-zip": "*",
-        "symfony/finder": "^6.0",
-        "symfony/http-foundation": "^6.0",
-        "symfony/mime": "^6.0",
-        "symfony/string": "^6.0"
+        "symfony/finder": "^5.4 || ^6.4 || ^7.0",
+        "symfony/http-foundation": "^5.4 || ^6.4 || ^7.0",
+        "symfony/mime": "^5.4 || ^6.4 || ^7.0",
+        "symfony/string": "^5.4 || ^6.4 || ^7.0"
     },
     "require-dev": {
         "dereuromark/composer-prefer-lowest": "^0.1.10",


### PR DESCRIPTION
As this project is a library, it should be installable with as many Symfony versions that still are supported in order to make it usable across as many projects as possible.

So reinstate compatibility with Symfony 5.4, and add compatibility with Symfony 7.0 and 7.1.

At the moment, Symfony 5.4, 6.4, 7.0 and 7.1 are still supported by the Symfony project:

https://symfony.com/releases

Closes #301