### PR TITLE
Add missing text search parameter to ProductGet

### DIFF
--- a/src/Type/ProductGet.php
+++ b/src/Type/ProductGet.php
@@ -19,6 +19,7 @@ namespace MarcusJaschen\Collmex\Type;
  * @property $system_name
  * @property $website_id
  * @property $with_price_only
+ * @property string|null $text
  */
 class ProductGet extends AbstractType implements TypeInterface
 {
@@ -44,6 +45,7 @@ class ProductGet extends AbstractType implements TypeInterface
         'system_name' => null,
         'website_id' => null,
         'with_price_only' => null,
+        'text' => null,
     ];
 
     /**


### PR DESCRIPTION
The Collmex API documents a `text` parameter at position 10 of the PRODUCT_GET request type (see [API docs](https://www.collmex.de/cgi-bin/cgi.exe?1005,1,help,api_Produkte)).

It filters products by searching across product number, description, English name, remarks, EAN and manufacturer fields.

This parameter was missing from the SDK's ProductGet type template.