### PR TITLE
feat: Add UTF-8 login flag and transliteration filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,12 +354,47 @@ foreach ($records as $record) {
 
 ## Notes
 
+### String encoding
+
 Collmex expects all strings encoded in code page 1252 (Windows) while the
 Collmex PHP SDK expects all inputs as UTF-8 and outputs everything as UTF-8.
 The conversion of string encodings is done transparently by using the
 Symfony String Component and PHP's `mb_convert_encoding()` function before
 sending a request to the Collmex API and after receiving the response from
 the API.
+
+#### UTF-8 mode
+
+Since May 2023, the Collmex API accepts UTF-8 encoded data when the LOGIN
+record contains a flag in the 4th field. To use this mode, pass `useUtf8: true`
+to the client constructor:
+
+```php
+$client = new \MarcusJaschen\Collmex\Client\Curl(
+    $user,
+    $password,
+    $customerId,
+    useUtf8: true,
+);
+```
+
+In this mode, the SDK skips the client-side encoding conversion and sends
+data as UTF-8 directly. Collmex converts to ISO-8859-1 server-side, replacing
+non-representable characters with `?`.
+
+#### Transliteration filter
+
+For characters outside the Windows-1252 range (e.g. `ā`, `ł`, `ø`), the
+default `mb_convert_encoding()` may produce garbled output. The alternative
+`Utf8ToWindows1252Translit` filter uses `iconv` with `//TRANSLIT` to
+approximate these characters instead (e.g. `ā` → `a`):
+
+```php
+use MarcusJaschen\Collmex\Filter\Utf8ToWindows1252Translit;
+
+$filter = new Utf8ToWindows1252Translit();
+$result = $filter->filterString('Kristiāna'); // "Kristiana"
+```
 
 ### Numeric / money values
 

--- a/src/Client/AbstractClient.php
+++ b/src/Client/AbstractClient.php
@@ -13,13 +13,24 @@ abstract class AbstractClient
 
     protected string $exchangeUrl;
 
-    public function __construct(protected string $user, protected string $password, string $customer)
-    {
+    protected bool $useUtf8 = false;
+
+    public function __construct(
+        protected string $user,
+        protected string $password,
+        string $customer,
+        bool $useUtf8 = false,
+    ) {
         $this->exchangeUrl = sprintf(static::EXCHANGE_URL, $customer);
+        $this->useUtf8 = $useUtf8;
     }
 
     protected function convertEncodingForCollmex(string $text): string
     {
+        if ($this->useUtf8) {
+            return $text;
+        }
+
         $filter = new Utf8ToWindows1252();
 
         return $filter->filterString($text);
@@ -33,6 +44,12 @@ abstract class AbstractClient
     {
         $csvGenerator = new Generator();
 
-        return $csvGenerator->generate(['LOGIN', $this->user, $this->password]);
+        $fields = ['LOGIN', $this->user, $this->password];
+
+        if ($this->useUtf8) {
+            $fields[] = '1';
+        }
+
+        return $csvGenerator->generate($fields);
     }
 }

--- a/src/Filter/Utf8ToWindows1252Translit.php
+++ b/src/Filter/Utf8ToWindows1252Translit.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MarcusJaschen\Collmex\Filter;
+
+use InvalidArgumentException;
+
+/**
+ * Converts UTF-8 to Windows-1252 with transliteration.
+ *
+ * Uses iconv with //TRANSLIT to approximate characters that don't exist
+ * in Windows-1252 (e.g. ā → a, ø → o, ł → l) instead of garbling them.
+ *
+ * Useful when sending data to Collmex without the UTF-8 LOGIN flag,
+ * or when Collmex's own UTF-8 → ISO-8859-1 conversion (which replaces
+ * non-representable characters with "?") is not acceptable.
+ */
+class Utf8ToWindows1252Translit extends AbstractFilter
+{
+    /**
+     * @throws InvalidArgumentException
+     */
+    #[\Override]
+    public function filterString(string $text): string
+    {
+        $result = iconv('UTF-8', 'Windows-1252//TRANSLIT', $text);
+
+        if ($result === false) {
+            // Fallback: drop unconvertible characters rather than failing
+            $result = iconv('UTF-8', 'Windows-1252//IGNORE', $text);
+        }
+
+        if ($result === false) {
+            throw new InvalidArgumentException(
+                'Cannot convert string to Windows-1252',
+                2_132_076_005
+            );
+        }
+
+        return $result;
+    }
+}

--- a/src/Type/Login.php
+++ b/src/Type/Login.php
@@ -12,6 +12,7 @@ namespace MarcusJaschen\Collmex\Type;
  * @property $type_identifier
  * @property $user
  * @property $password
+ * @property string|null $utf8
  */
 class Login extends AbstractType implements TypeInterface
 {
@@ -22,7 +23,24 @@ class Login extends AbstractType implements TypeInterface
         'type_identifier' => 'LOGIN',
         'user' => null,
         'password' => null,
+        'utf8' => null,
     ];
+
+    /**
+     * Returns CSV representation, omitting the utf8 field when not set
+     * to avoid sending an empty 4th field to Collmex.
+     */
+    #[\Override]
+    public function getCsv(): string
+    {
+        $data = $this->data;
+
+        if ($data['utf8'] === null || $data['utf8'] === '') {
+            unset($data['utf8']);
+        }
+
+        return $this->csvGenerator->generate([$data]);
+    }
 
     /**
      * Formally validates the type data in $data attribute.

--- a/tests/Unit/Client/CurlTest.php
+++ b/tests/Unit/Client/CurlTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MarcusJaschen\Collmex\Tests\Unit\Client;
+
+use MarcusJaschen\Collmex\Client\Curl;
+use PHPUnit\Framework\TestCase;
+
+class CurlTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function loginLineWithoutUtf8HasThreeFields(): void
+    {
+        $client = new Curl('user', 'pass', '1');
+
+        $method = new \ReflectionMethod($client, 'getLoginLine');
+
+        $result = $method->invoke($client);
+
+        self::assertSame("LOGIN;user;pass\n", $result);
+    }
+
+    /**
+     * @test
+     */
+    public function loginLineWithUtf8HasFourthFieldSetToOne(): void
+    {
+        $client = new Curl('user', 'pass', '1', useUtf8: true);
+
+        $method = new \ReflectionMethod($client, 'getLoginLine');
+
+        $result = $method->invoke($client);
+
+        self::assertSame("LOGIN;user;pass;1\n", $result);
+    }
+
+    /**
+     * @test
+     */
+    public function convertEncodingDefaultConvertsToWindows1252(): void
+    {
+        $client = new Curl('user', 'pass', '1');
+
+        $method = new \ReflectionMethod($client, 'convertEncodingForCollmex');
+
+        $input = 'Ä';
+        $result = $method->invoke($client, $input);
+
+        self::assertSame(
+            mb_convert_encoding('Ä', 'Windows-1252', 'UTF-8'),
+            $result
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function convertEncodingWithUtf8ReturnsInputUnchanged(): void
+    {
+        $client = new Curl('user', 'pass', '1', useUtf8: true);
+
+        $method = new \ReflectionMethod($client, 'convertEncodingForCollmex');
+
+        $input = 'Kristiāna Ä';
+        $result = $method->invoke($client, $input);
+
+        self::assertSame($input, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function useUtf8DefaultsToFalse(): void
+    {
+        $client = new Curl('user', 'pass', '1');
+
+        $method = new \ReflectionMethod($client, 'getLoginLine');
+
+        $result = $method->invoke($client);
+
+        self::assertStringNotContainsString(';1', substr($result, strpos($result, 'pass') + 4));
+    }
+}

--- a/tests/Unit/Filter/Utf8ToWindows1252TranslitTest.php
+++ b/tests/Unit/Filter/Utf8ToWindows1252TranslitTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MarcusJaschen\Collmex\Tests\Unit\Filter;
+
+use MarcusJaschen\Collmex\Filter\FilterInterface;
+use MarcusJaschen\Collmex\Filter\Utf8ToWindows1252Translit;
+use PHPUnit\Framework\TestCase;
+
+class Utf8ToWindows1252TranslitTest extends TestCase
+{
+    protected Utf8ToWindows1252Translit $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new Utf8ToWindows1252Translit();
+    }
+
+    /**
+     * @test
+     */
+    public function implementsFilterInterface(): void
+    {
+        self::assertInstanceOf(FilterInterface::class, $this->subject);
+    }
+
+    /**
+     * @test
+     */
+    public function filterStringKeepsAsciiTextUnchanged(): void
+    {
+        $text = 'There is no spoon.';
+
+        $result = $this->subject->filterString($text);
+
+        self::assertSame($text, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function filterStringConvertsWindows1252CompatibleCharacters(): void
+    {
+        $input = \file_get_contents(__DIR__ . '/Fixtures/utf-8.txt');
+        $expected = \file_get_contents(__DIR__ . '/Fixtures/cp1252.txt');
+
+        $result = $this->subject->filterString($input);
+
+        self::assertSame($expected, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function filterStringTransliteratesNonWindows1252Characters(): void
+    {
+        // ā (a with macron) is not in Windows-1252, should become "a"
+        $result = $this->subject->filterString('Kristiāna');
+
+        self::assertSame('Kristiana', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function filterStringTransliteratesMixedContent(): void
+    {
+        // German umlauts (in CP1252) stay intact, ā gets transliterated
+        $result = $this->subject->filterString('Müller-Kristiāna');
+        $expected = mb_convert_encoding('Müller-Kristiana', 'Windows-1252', 'UTF-8');
+
+        self::assertSame($expected, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function filterStringHandlesEmptyString(): void
+    {
+        $result = $this->subject->filterString('');
+
+        self::assertSame('', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function filterStringHandlesUntranslieterableCharacters(): void
+    {
+        // CJK characters cannot be transliterated to Latin, should not throw
+        $result = $this->subject->filterString('Test 中文 Ende');
+
+        // Result should contain "Test" and "Ende", CJK replaced with fallback
+        self::assertStringContainsString('Test', $result);
+        self::assertStringContainsString('Ende', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function filterArrayTransliteratesValues(): void
+    {
+        $input = ['Kristiāna', 'Müller'];
+        $result = $this->subject->filterArray($input);
+
+        self::assertSame('Kristiana', $result[0]);
+        self::assertSame(
+            mb_convert_encoding('Müller', 'Windows-1252', 'UTF-8'),
+            $result[1]
+        );
+    }
+}

--- a/tests/Unit/Type/LoginTest.php
+++ b/tests/Unit/Type/LoginTest.php
@@ -30,4 +30,44 @@ class LoginTest extends TestCase
 
         self::assertInstanceOf(TypeInterface::class, $subject);
     }
+
+    /**
+     * @test
+     */
+    public function getCsvWithoutUtf8OmitsTrailingField(): void
+    {
+        $subject = new Login([
+            'user' => 'testuser',
+            'password' => 'testpass',
+        ]);
+
+        self::assertSame("LOGIN;testuser;testpass\n", $subject->getCsv());
+    }
+
+    /**
+     * @test
+     */
+    public function getCsvWithoutUtf8DoesNotTrimEmptyPassword(): void
+    {
+        $subject = new Login([
+            'user' => 'testuser',
+            'password' => '',
+        ]);
+
+        self::assertSame("LOGIN;testuser;\n", $subject->getCsv());
+    }
+
+    /**
+     * @test
+     */
+    public function getCsvWithUtf8IncludesFourthField(): void
+    {
+        $subject = new Login([
+            'user' => 'testuser',
+            'password' => 'testpass',
+            'utf8' => '1',
+        ]);
+
+        self::assertSame("LOGIN;testuser;testpass;1\n", $subject->getCsv());
+    }
 }


### PR DESCRIPTION
## Summary

Since May 2023, the Collmex API supports UTF-8 encoded data via a flag in the LOGIN record ([changelog entry](https://www.collmex.de/neues.html), see "5.5.2023: API jetzt auch mit UTF-8 Zeichensatz nutzbar"). This PR adds two opt-in features to support this and to improve handling of characters outside the Windows-1252 range.

### Problem

Characters outside Windows-1252 (e.g. `ā`, `ł`, `ø` — common in Latvian, Polish, Scandinavian names) are silently garbled by `mb_convert_encoding()` in the current `Utf8ToWindows1252` filter. This leads to corrupted customer/order data in Collmex.

### Solution

**1. UTF-8 mode (`$useUtf8` constructor parameter)**

The Collmex API now accepts a 4th field in the LOGIN record. When set to `1`, Collmex accepts UTF-8 input and converts to ISO-8859-1 server-side (replacing non-representable characters with `?`).

```php
$client = new \MarcusJaschen\Collmex\Client\Curl(
    $user,
    $password,
    $customerId,
    useUtf8: true,
);
```

When enabled:
- The LOGIN CSV line includes the UTF-8 flag as 4th field: `LOGIN;user;pass;1`
- `convertEncodingForCollmex()` skips the client-side CP1252 conversion (Collmex handles it)

**2. Transliteration filter (`Utf8ToWindows1252Translit`)**

Alternative to `Utf8ToWindows1252` that uses `iconv` with `//TRANSLIT` instead of `mb_convert_encoding()`. This approximates non-CP1252 characters instead of garbling them:

| Input | `Utf8ToWindows1252` (current) | `Utf8ToWindows1252Translit` (new) |
|-------|-------------------------------|-----------------------------------|
| `Kristiāna` | garbled output | `Kristiana` |
| `Müller` | `Müller` (unchanged) | `Müller` (unchanged) |
| `André` | `André` (unchanged) | `André` (unchanged) |

```php
use MarcusJaschen\Collmex\Filter\Utf8ToWindows1252Translit;

$filter = new Utf8ToWindows1252Translit();
$result = $filter->filterString('Kristiāna'); // "Kristiana"
```

**3. Login type: `utf8` field**

The `Login` type template now includes an optional `utf8` field. When not set, `getCsv()` omits the 4th field entirely to maintain backward compatibility (no trailing semicolon).

## Changes

| File | Change |
|------|--------|
| `src/Client/AbstractClient.php` | Added `$useUtf8` constructor param (default `false`), conditional encoding skip, UTF-8 flag in login line |
| `src/Type/Login.php` | Added `utf8` field to template, `getCsv()` override to omit empty trailing field |
| `src/Filter/Utf8ToWindows1252Translit.php` | New filter using `iconv //TRANSLIT` |
| `tests/Unit/Client/CurlTest.php` | 5 tests for login line and encoding behavior |
| `tests/Unit/Type/LoginTest.php` | 3 new tests for CSV output with/without UTF-8 flag |
| `tests/Unit/Filter/Utf8ToWindows1252TranslitTest.php` | 8 tests incl. transliteration, CP1252-compatible chars, CJK fallback |
| `README.md` | Documentation for both features |

## Backward compatibility

Both features are fully opt-in:
- `$useUtf8` defaults to `false` — existing behavior unchanged
- `Utf8ToWindows1252Translit` is a new class — existing code not affected
- `Login` getCsv() omits the `utf8` field when null — output identical to before

## Test plan

- [x] All 189 tests pass (173 existing + 16 new)
- [x] phpstan: no errors
- [x] phpcs: no warnings
- [x] Verified `Login::getCsv()` produces identical output to before when `utf8` is not set
- [x] Verified empty password is NOT trimmed by the trailing-field logic
- [x] Verified `iconv //TRANSLIT` does not emit notices on PHP 8.4 for untransliterable characters (CJK → `?`)

## References

- Collmex changelog (May 2023): "Der Import von Daten über das API kann jetzt auch in der Codierung UTF-8 erfolgen. In der Satzart LOGIN gibt es dazu ein neues Kennzeichen."
- Collmex FAQ: "Das System ist auf den Zeichensatz ISO-8859-1 beschränkt. Nicht darstellbare Zeichen werden durch ein ? ersetzt."