### PR TITLE
Add redemption_count field to Voucher type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/)
 principles.
 
+## [Unreleased]
+
+### Added
+
+- new field to `VOUCHER`: `redemption_count`
+
 ## [3.9.0]
 
 ### Added

--- a/src/Type/Voucher.php
+++ b/src/Type/Voucher.php
@@ -21,6 +21,7 @@ namespace MarcusJaschen\Collmex\Type;
  * @property $agent_id
  * @property $min_order_value
  * @property $currency
+ * @property $redemption_count
  */
 class Voucher extends AbstractType implements TypeInterface
 {
@@ -40,6 +41,7 @@ class Voucher extends AbstractType implements TypeInterface
         'agent_id' => null,
         'min_order_value' => null,
         'currency' => null,
+        'redemption_count' => null,
     ];
 
     /**

--- a/tests/Unit/Type/VoucherTest.php
+++ b/tests/Unit/Type/VoucherTest.php
@@ -30,4 +30,30 @@ class VoucherTest extends TestCase
 
         self::assertInstanceOf(TypeInterface::class, $subject);
     }
+
+    /**
+     * @test
+     */
+    public function populatesRedemptionCountFromCsvData(): void
+    {
+        $data = [
+            'VOUCHER',
+            '123-456',
+            '1',
+            '0',
+            '20250101',
+            '20261231',
+            '0',
+            '50,00',
+            'Test',
+            '',
+            '',
+            'EUR',
+            '3',
+        ];
+
+        $subject = new Voucher($data);
+
+        self::assertSame('3', $subject->redemption_count);
+    }
 }


### PR DESCRIPTION
## Summary

Add field 13 (`redemption_count`) to the `VOUCHER` type template as documented in the Collmex API documentation (Hilfe → API → Gutscheine).

This field tracks how many times a voucher has been redeemed and is returned by the `VOUCHER_GET` query.

| Nr | Field | Type | Max Length | Description |
|---|---|---|---|---|
| 13 | Anzahl Einlösungen | I | 8 | How many times the voucher has been redeemed |

Fixes #363