### PR TITLE
Add new type CustomerAgreement (CMXCAG)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/)
 principles.
 
+## [Unreleased]
+
+### Added
+
+- new type `CustomerAgreement` (`CMXCAG`)
+- new type `CustomerAgreementGet` (`CUSTOMER_AGREEMENT_GET`)
+
 ## [3.9.0]
 
 ### Added

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -763,6 +763,114 @@ parameters:
 			path: src/Type/Customer.php
 
 		-
+			message: '#^PHPDoc tag @property has invalid value \(\$client_id\)\: Unexpected token "\$client_id", expected type at offset 150 on line 7$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Type/CustomerAgreement.php
+
+		-
+			message: '#^PHPDoc tag @property has invalid value \(\$currency\)\: Unexpected token "\$currency", expected type at offset 316 on line 14$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Type/CustomerAgreement.php
+
+		-
+			message: '#^PHPDoc tag @property has invalid value \(\$customer_id\)\: Unexpected token "\$customer_id", expected type at offset 174 on line 8$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Type/CustomerAgreement.php
+
+		-
+			message: '#^PHPDoc tag @property has invalid value \(\$deleted\)\: Unexpected token "\$deleted", expected type at offset 339 on line 15$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Type/CustomerAgreement.php
+
+		-
+			message: '#^PHPDoc tag @property has invalid value \(\$position\)\: Unexpected token "\$position", expected type at offset 225 on line 10$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Type/CustomerAgreement.php
+
+		-
+			message: '#^PHPDoc tag @property has invalid value \(\$price\)\: Unexpected token "\$price", expected type at offset 296 on line 13$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Type/CustomerAgreement.php
+
+		-
+			message: '#^PHPDoc tag @property has invalid value \(\$product_id\)\: Unexpected token "\$product_id", expected type at offset 200 on line 9$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Type/CustomerAgreement.php
+
+		-
+			message: '#^PHPDoc tag @property has invalid value \(\$type_identifier\)\: Unexpected token "\$type_identifier", expected type at offset 120 on line 6$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Type/CustomerAgreement.php
+
+		-
+			message: '#^PHPDoc tag @property has invalid value \(\$valid_from\)\: Unexpected token "\$valid_from", expected type at offset 248 on line 11$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Type/CustomerAgreement.php
+
+		-
+			message: '#^PHPDoc tag @property has invalid value \(\$valid_to\)\: Unexpected token "\$valid_to", expected type at offset 273 on line 12$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Type/CustomerAgreement.php
+
+		-
+			message: '#^PHPDoc tag @property has invalid value \(\$changed_only\)\: Unexpected token "\$changed_only", expected type at offset 271 on line 12$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Type/CustomerAgreementGet.php
+
+		-
+			message: '#^PHPDoc tag @property has invalid value \(\$client_id\)\: Unexpected token "\$client_id", expected type at offset 145 on line 7$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Type/CustomerAgreementGet.php
+
+		-
+			message: '#^PHPDoc tag @property has invalid value \(\$customer_id\)\: Unexpected token "\$customer_id", expected type at offset 169 on line 8$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Type/CustomerAgreementGet.php
+
+		-
+			message: '#^PHPDoc tag @property has invalid value \(\$inactive\)\: Unexpected token "\$inactive", expected type at offset 248 on line 11$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Type/CustomerAgreementGet.php
+
+		-
+			message: '#^PHPDoc tag @property has invalid value \(\$product_id\)\: Unexpected token "\$product_id", expected type at offset 195 on line 9$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Type/CustomerAgreementGet.php
+
+		-
+			message: '#^PHPDoc tag @property has invalid value \(\$system_name\)\: Unexpected token "\$system_name", expected type at offset 298 on line 13$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Type/CustomerAgreementGet.php
+
+		-
+			message: '#^PHPDoc tag @property has invalid value \(\$type_identifier\)\: Unexpected token "\$type_identifier", expected type at offset 115 on line 6$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Type/CustomerAgreementGet.php
+
+		-
+			message: '#^PHPDoc tag @property has invalid value \(\$validity_date\)\: Unexpected token "\$validity_date", expected type at offset 220 on line 10$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Type/CustomerAgreementGet.php
+
+		-
 			message: '#^PHPDoc tag @property has invalid value \(\$address_group_id\)\: Unexpected token "\$address_group_id", expected type at offset 248 on line 12$#'
 			identifier: phpDoc.parseError
 			count: 1
@@ -6327,6 +6435,30 @@ parameters:
 			identifier: method.notFound
 			count: 2
 			path: tests/Unit/Response/CsvResponseTest.php
+
+		-
+			message: '#^Access to an undefined property MarcusJaschen\\Collmex\\Type\\CustomerAgreement\:\:\$customer_id\.$#'
+			identifier: property.notFound
+			count: 1
+			path: tests/Unit/Type/CustomerAgreementTest.php
+
+		-
+			message: '#^Access to an undefined property MarcusJaschen\\Collmex\\Type\\CustomerAgreement\:\:\$deleted\.$#'
+			identifier: property.notFound
+			count: 1
+			path: tests/Unit/Type/CustomerAgreementTest.php
+
+		-
+			message: '#^Access to an undefined property MarcusJaschen\\Collmex\\Type\\CustomerAgreement\:\:\$price\.$#'
+			identifier: property.notFound
+			count: 1
+			path: tests/Unit/Type/CustomerAgreementTest.php
+
+		-
+			message: '#^Access to an undefined property MarcusJaschen\\Collmex\\Type\\CustomerAgreement\:\:\$product_id\.$#'
+			identifier: property.notFound
+			count: 1
+			path: tests/Unit/Type/CustomerAgreementTest.php
 
 		-
 			message: '#^Access to an undefined property MarcusJaschen\\Collmex\\Type\\Subscription\:\:\$interval\.$#'

--- a/src/Type/CustomerAgreement.php
+++ b/src/Type/CustomerAgreement.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MarcusJaschen\Collmex\Type;
+
+/**
+ * Collmex Customer Agreement Type (CMXCAG).
+ *
+ * @author   Marcus Jaschen <mail@marcusjaschen.de>
+ *
+ * @property $type_identifier
+ * @property $client_id
+ * @property $customer_id
+ * @property $product_id
+ * @property $position
+ * @property $valid_from
+ * @property $valid_to
+ * @property $price
+ * @property $currency
+ * @property $deleted
+ */
+class CustomerAgreement extends AbstractType implements TypeInterface
+{
+    /**
+     * Type data template.
+     *
+     * @var array
+     */
+    protected $template = [
+        'type_identifier' => 'CMXCAG',
+        'client_id' => null,
+        'customer_id' => null,
+        'product_id' => null,
+        'position' => null,
+        'valid_from' => null,
+        'valid_to' => null,
+        'price' => null,
+        'currency' => null,
+        'deleted' => null,
+    ];
+
+    /**
+     * Formally validates the type data in $data attribute.
+     *
+     * @return bool Validation success
+     */
+    #[\Override]
+    public function validate(): bool
+    {
+        return true;
+    }
+}

--- a/src/Type/CustomerAgreementGet.php
+++ b/src/Type/CustomerAgreementGet.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MarcusJaschen\Collmex\Type;
+
+/**
+ * Collmex Customer Agreement Get Type.
+ *
+ * @author   Marcus Jaschen <mail@marcusjaschen.de>
+ *
+ * @property $type_identifier
+ * @property $client_id
+ * @property $customer_id
+ * @property $product_id
+ * @property $validity_date
+ * @property $inactive
+ * @property $changed_only
+ * @property $system_name
+ */
+class CustomerAgreementGet extends AbstractType implements TypeInterface
+{
+    /**
+     * @var array
+     */
+    protected $template = [
+        'type_identifier' => 'CUSTOMER_AGREEMENT_GET',
+        'client_id' => null,
+        'customer_id' => null,
+        'product_id' => null,
+        'validity_date' => null,
+        'inactive' => null,
+        'changed_only' => null,
+        'system_name' => null,
+    ];
+
+    /**
+     * Formally validates the type data in $data attribute.
+     *
+     * @return bool Validation success
+     */
+    #[\Override]
+    public function validate(): bool
+    {
+        return true;
+    }
+}

--- a/src/TypeFactory.php
+++ b/src/TypeFactory.php
@@ -12,6 +12,7 @@ use MarcusJaschen\Collmex\Type\AddressGroups;
 use MarcusJaschen\Collmex\Type\Batch;
 use MarcusJaschen\Collmex\Type\BillOfMaterial;
 use MarcusJaschen\Collmex\Type\Customer;
+use MarcusJaschen\Collmex\Type\CustomerAgreement;
 use MarcusJaschen\Collmex\Type\CustomerOrder;
 use MarcusJaschen\Collmex\Type\Delivery;
 use MarcusJaschen\Collmex\Type\DifferentShippingAddress;
@@ -60,6 +61,7 @@ class TypeFactory
         'CMXADR' => Address::class,
         'CMXBOM' => BillOfMaterial::class,
         'CMXBTC' => Batch::class,
+        'CMXCAG' => CustomerAgreement::class,
         'CMXDLV' => Delivery::class,
         'EMPLOYEE' => Employee::class,
         'CMXEPF' => DifferentShippingAddress::class,

--- a/tests/Unit/Type/CustomerAgreementGetTest.php
+++ b/tests/Unit/Type/CustomerAgreementGetTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MarcusJaschen\Collmex\Tests\Unit\Type;
+
+use MarcusJaschen\Collmex\Type\AbstractType;
+use MarcusJaschen\Collmex\Type\CustomerAgreementGet;
+use MarcusJaschen\Collmex\Type\TypeInterface;
+use PHPUnit\Framework\TestCase;
+
+class CustomerAgreementGetTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function isAbstractType(): void
+    {
+        $subject = new CustomerAgreementGet([]);
+
+        self::assertInstanceOf(AbstractType::class, $subject);
+    }
+
+    /**
+     * @test
+     */
+    public function implementsTypeInterface(): void
+    {
+        $subject = new CustomerAgreementGet([]);
+
+        self::assertInstanceOf(TypeInterface::class, $subject);
+    }
+
+    /**
+     * @test
+     */
+    public function generatesCsvWithFilters(): void
+    {
+        $subject = new CustomerAgreementGet([
+            'client_id' => '1',
+            'customer_id' => '12345',
+            'changed_only' => '1',
+            'system_name' => 'SentaNG',
+        ]);
+
+        $csv = $subject->getCsv();
+
+        self::assertStringContainsString('CUSTOMER_AGREEMENT_GET', $csv);
+        self::assertStringContainsString('12345', $csv);
+        self::assertStringContainsString('SentaNG', $csv);
+    }
+}

--- a/tests/Unit/Type/CustomerAgreementTest.php
+++ b/tests/Unit/Type/CustomerAgreementTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MarcusJaschen\Collmex\Tests\Unit\Type;
+
+use MarcusJaschen\Collmex\Type\AbstractType;
+use MarcusJaschen\Collmex\Type\CustomerAgreement;
+use MarcusJaschen\Collmex\Type\TypeInterface;
+use PHPUnit\Framework\TestCase;
+
+class CustomerAgreementTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function isAbstractType(): void
+    {
+        $subject = new CustomerAgreement([]);
+
+        self::assertInstanceOf(AbstractType::class, $subject);
+    }
+
+    /**
+     * @test
+     */
+    public function implementsTypeInterface(): void
+    {
+        $subject = new CustomerAgreement([]);
+
+        self::assertInstanceOf(TypeInterface::class, $subject);
+    }
+
+    /**
+     * @test
+     */
+    public function populatesFieldsFromCsvData(): void
+    {
+        $data = [
+            'CMXCAG',
+            '1',
+            '12345',
+            'PAC01001',
+            '1',
+            '20250101',
+            '99991231',
+            '8,50',
+            'EUR',
+            '0',
+        ];
+
+        $subject = new CustomerAgreement($data);
+
+        self::assertSame('12345', $subject->customer_id);
+        self::assertSame('PAC01001', $subject->product_id);
+        self::assertSame('8,50', $subject->price);
+        self::assertSame('0', $subject->deleted);
+    }
+
+    /**
+     * @test
+     */
+    public function generatesCsv(): void
+    {
+        $subject = new CustomerAgreement([
+            'client_id' => '1',
+            'customer_id' => '12345',
+            'product_id' => 'PAC01001',
+            'valid_from' => '20250101',
+            'valid_to' => '99991231',
+            'price' => '8,50',
+            'currency' => 'EUR',
+            'deleted' => '1',
+        ]);
+
+        $csv = $subject->getCsv();
+
+        self::assertStringContainsString('CMXCAG', $csv);
+        self::assertStringContainsString('12345', $csv);
+        self::assertStringContainsString('PAC01001', $csv);
+        self::assertStringContainsString('8,50', $csv);
+    }
+}


### PR DESCRIPTION
## Summary

Add a new `CustomerAgreement` type for customer-specific price agreements (`CMXCAG`).

### Fields (10)

| Pos | Field | Type | Description |
|-----|-------|------|-------------|
| 1 | Satzart | C | `CMXCAG` |
| 2 | Firma Nr | I | Client ID |
| 3 | Kunde Nr | I | Customer ID |
| 4 | Produktnummer | C | Product ID |
| 5 | Position | I | Position number |
| 6 | Gültig ab | D | Valid from |
| 7 | Gültig bis | D | Valid to |
| 8 | Preis | M | Price |
| 9 | Währung | C | Currency |
| 10 | Gelöscht | I | Deleted flag (0/1) |

### Changes

- New type class `CustomerAgreement` (analog to `ProductPrice`)
- Registered `CMXCAG` in `TypeFactory`
- Tests for type instantiation, CSV parsing, and CSV generation
- CHANGELOG entry